### PR TITLE
Switch to global script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
         </section>
     </main>
 
+    <!-- Load Three.js library -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+
     <!-- Load the app -->
     <script type="module" src="scripts/app.js"></script>
     

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,6 +1,3 @@
-import { initBingo3D } from './bingo3d.js';
-import { initVerseOfTheHour } from './verseOfTheHour.js';
-import { initPolls } from './polls.js';
 
 // Tab switching functionality
 function initTabs() {
@@ -41,15 +38,13 @@ function initTabs() {
 async function initializeApp() {
     try {
         console.log('Initializing GatherTogether app...');
-        
-        // Initialize tabs first
+
         initTabs();
-        
-        // Initialize modules
-        await initBingo3D();
-        initVerseOfTheHour();
-        initPolls();
-        
+
+        await window.initBingo3D();
+        window.initVerseOfTheHour();
+        window.initPolls();
+
         console.log('App initialized successfully');
     } catch (error) {
         console.error('Error initializing app:', error);

--- a/scripts/bingo3d.js
+++ b/scripts/bingo3d.js
@@ -1,4 +1,3 @@
-import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
 
 // Bingo challenges for LCMS Youth Gathering
 const CHALLENGES = [
@@ -45,6 +44,9 @@ export function initBingo3D() {
         container.innerHTML = '<p class="text-red-600">Error loading 3D bingo. Please refresh the page.</p>';
     }
 }
+
+// Expose initializer globally
+window.initBingo3D = initBingo3D;
 
 function setupScene(container) {
     // Scene setup
@@ -511,3 +513,6 @@ function animate() {
     
     renderer.render(scene, camera);
 }
+
+// Expose initializer globally
+window.initBingo3D = initBingo3D;

--- a/scripts/polls.js
+++ b/scripts/polls.js
@@ -4,3 +4,6 @@ export function initPolls() {
         container.textContent = 'Polls and Q&A coming soon...';
     }
 }
+
+// Expose initializer globally
+window.initPolls = initPolls;

--- a/scripts/verseOfTheHour.js
+++ b/scripts/verseOfTheHour.js
@@ -13,3 +13,6 @@ export function initVerseOfTheHour() {
     const index = hour % verses.length;
     verseText.textContent = verses[index];
 }
+
+// Expose initializer globally
+window.initVerseOfTheHour = initVerseOfTheHour;


### PR DESCRIPTION
## Summary
- load Three.js with a CDN script tag
- expose bingo3d, verseOfTheHour and polls initializers globally
- adjust app initialization to use global functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877f0c4f1448331bc60e7ba51808b9e