### PR TITLE
Close mobile menu when switching tabs

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -25,6 +25,12 @@ const App = {
                 e.preventDefault();
                 const targetId = link.getAttribute('href').substring(1);
                 App.switchTab(targetId);
+
+                // Hide the navigation menu on mobile after selecting a tab
+                const nav = document.getElementById('nav');
+                if (nav && (window.innerWidth < 768 || nav.classList.contains('md:hidden'))) {
+                    nav.classList.add('hidden');
+                }
             });
         });
 


### PR DESCRIPTION
## Summary
- close the mobile navigation menu when selecting a tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878017432dc8331a2e30c45b6819ae4