### PR TITLE
Add Node backend for polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ GatherTogether/
 │   └── utils.js            # Utility functions
 └── README.md               # Documentation
 ```
+
+## Running the server
+
+The polls feature relies on a small Node.js API. Install dependencies and start
+the server:
+
+```bash
+npm install
+node server.js
+```
+
+The app will be available at `http://localhost:3000` and the polls API can be
+reached at `http://localhost:3000/api/polls`.

--- a/data/polls.json
+++ b/data/polls.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "youth-gathering-excitement",
+    "question": "How excited are you for the Youth Gathering?",
+    "options": [
+      { "id": "very-excited", "text": "Very excited! 🎉", "votes": 0 },
+      { "id": "excited", "text": "Excited 😊", "votes": 0 },
+      { "id": "somewhat", "text": "Somewhat excited 😐", "votes": 0 },
+      { "id": "not-sure", "text": "Not sure yet 🤔", "votes": 0 }
+    ],
+    "allowMultiple": false,
+    "active": true
+  },
+  {
+    "id": "favorite-activity",
+    "question": "What are you most looking forward to?",
+    "options": [
+      { "id": "worship", "text": "Worship services 🙏", "votes": 0 },
+      { "id": "sessions", "text": "Learning sessions 📚", "votes": 0 },
+      { "id": "friends", "text": "Meeting new friends 👥", "votes": 0 },
+      { "id": "service", "text": "Service opportunities 🤝", "votes": 0 },
+      { "id": "activities", "text": "Fun activities 🎮", "votes": 0 }
+    ],
+    "allowMultiple": true,
+    "active": true
+  }
+]

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
                 <div class="text-center mb-6">
                     <h2 class="text-3xl font-bold text-gray-800 mb-2">Live Polls & Q&A</h2>
                     <p class="text-gray-600">Connect with other youth and share your thoughts</p>
+                    <p class="text-gray-600">Poll data is loaded from <code>/api/polls</code>. Start the server to enable voting.</p>
                 </div>
                 
                 <div id="polls-container">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gathertogether",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_PATH = path.join(__dirname, 'data', 'polls.json');
+
+const SAMPLE_POLLS = [
+  {
+    id: 'youth-gathering-excitement',
+    question: 'How excited are you for the Youth Gathering?',
+    options: [
+      { id: 'very-excited', text: 'Very excited! 🎉', votes: 0 },
+      { id: 'excited', text: 'Excited 😊', votes: 0 },
+      { id: 'somewhat', text: 'Somewhat excited 😐', votes: 0 },
+      { id: 'not-sure', text: 'Not sure yet 🤔', votes: 0 }
+    ],
+    allowMultiple: false,
+    active: true
+  },
+  {
+    id: 'favorite-activity',
+    question: 'What are you most looking forward to?',
+    options: [
+      { id: 'worship', text: 'Worship services 🙏', votes: 0 },
+      { id: 'sessions', text: 'Learning sessions 📚', votes: 0 },
+      { id: 'friends', text: 'Meeting new friends 👥', votes: 0 },
+      { id: 'service', text: 'Service opportunities 🤝', votes: 0 },
+      { id: 'activities', text: 'Fun activities 🎮', votes: 0 }
+    ],
+    allowMultiple: true,
+    active: true
+  }
+];
+
+function loadPolls() {
+  if (fs.existsSync(DATA_PATH)) {
+    try {
+      const data = fs.readFileSync(DATA_PATH, 'utf8');
+      return JSON.parse(data);
+    } catch (err) {
+      console.error('Error reading polls file:', err);
+    }
+  }
+  savePolls(SAMPLE_POLLS);
+  return JSON.parse(JSON.stringify(SAMPLE_POLLS));
+}
+
+function savePolls(polls) {
+  fs.mkdirSync(path.dirname(DATA_PATH), { recursive: true });
+  fs.writeFileSync(DATA_PATH, JSON.stringify(polls, null, 2));
+}
+
+let polls = loadPolls();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(express.static(__dirname));
+
+app.get('/api/polls', (req, res) => {
+  res.json(polls);
+});
+
+app.post('/api/polls/:pollId/vote', (req, res) => {
+  const { pollId } = req.params;
+  const { optionId } = req.body;
+  const poll = polls.find(p => p.id === pollId);
+  if (!poll) return res.status(404).json({ error: 'Poll not found' });
+  const option = poll.options.find(o => o.id === optionId);
+  if (!option) return res.status(400).json({ error: 'Option not found' });
+
+  option.votes = (option.votes || 0) + 1;
+  savePolls(polls);
+  res.json(poll);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create basic Express server that stores poll data and exposes a voting API
- add package.json with express and cors deps
- persist initial polls in `data/polls.json`
- fetch polls from the API and send votes via `POST`
- document how to run the server
- note API usage on the polls page

## Testing
- `npm install`
- `node server.js` (launched and printed running message)

------
https://chatgpt.com/codex/tasks/task_e_6878092f4dbc8331997e56b79354d5eb