### PR TITLE
Add sublists for completionist bingo

### DIFF
--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -5,6 +5,7 @@ const Storage = {
     KEYS: {
         BINGO_PROGRESS_REGULAR: 'bingoProgressRegular',
         BINGO_PROGRESS_COMPLETIONIST: 'bingoProgressCompletionist',
+        BINGO_SUBITEMS_COMPLETIONIST: 'bingoSubItemsCompletionist',
         FAVORITE_VERSES: 'favoriteVerses',
         POLL_RESPONSES: 'pollResponses',
         USER_PREFERENCES: 'userPreferences',

--- a/styles/global.css
+++ b/styles/global.css
@@ -312,6 +312,34 @@ body {
     animation: confettiFall 3s linear infinite;
 }
 
+.bingo-sub-progress {
+    font-size: 0.7rem;
+    color: #4b5563;
+    margin-top: 0.25rem;
+}
+
+.sublist-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    animation: fadeIn 0.3s ease;
+}
+
+.sublist-content {
+    background: white;
+    padding: 2rem;
+    border-radius: 1rem;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
 @keyframes confettiFall {
     to {
         transform: translateY(100vh) rotate(360deg);


### PR DESCRIPTION
## Summary
- expand completionist bingo list to include required subitems
- track subitem progress in local storage
- show progress numbers on tiles
- add modal interface for checking off subitems
- style new progress and modal elements

## Testing
- `npm install`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68780bced5ac8331b3138860d51364e3