### PR TITLE
Update mobile nav style

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                 <button id="menu-toggle" class="md:hidden text-gray-800 focus:outline-none text-2xl">
                     &#9776;
                 </button>
-                <ul class="hidden flex-col space-y-2 absolute right-4 top-full bg-white nav-glass p-4 rounded-md z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0" id="nav">
+                <ul id="nav" class="hidden fixed inset-0 nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
                     <li><a href="#bingo" class="tab-link active">Bingo Tracker</a></li>
                     <li><a href="#verse" class="tab-link">Verse of the Hour</a></li>
                     <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>

--- a/styles/global.css
+++ b/styles/global.css
@@ -491,4 +491,25 @@ body {
     .stats-container {
         grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
+
+    /* Full-screen mobile navigation */
+    #nav {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 1.5rem;
+        padding: 2rem;
+        background: var(--glass-bg);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        z-index: 100;
+    }
+
+    #nav li a {
+        font-size: 1.5rem;
+        padding: 0.75rem 1rem;
+    }
 }


### PR DESCRIPTION
## Summary
- make navigation overlay fill the entire screen on mobile
- grow nav links for easier tapping

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68781157e0ec833182e9af52ab23a065