### PR TITLE
Improve completionist bingo UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
                         <div class="stat-number" id="bingo-count">0</div>
                         <div class="stat-label">Bingo Lines</div>
                     </div>
+                    <div class="stat-card">
+                        <div class="stat-number" id="achievement-count">0</div>
+                        <div class="stat-label">Achievements</div>
+                    </div>
                 </div>
 
                 <div class="text-center mt-6">

--- a/styles/global.css
+++ b/styles/global.css
@@ -363,12 +363,32 @@ body {
 }
 
 .sublist-items li {
-    padding: 0.5rem 0;
-    border-bottom: 1px solid #e5e7eb;
+    padding: 0.25rem 0;
+    border-bottom: none;
 }
 
-.sublist-items li:last-child {
-    border-bottom: none;
+
+.sub-item-btn {
+    display: block;
+    width: 100%;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.sub-item-btn:hover {
+    background: rgba(124,58,237,0.1);
+    border-color: var(--primary-purple);
+}
+
+.sub-item-btn.selected {
+    background: var(--primary-purple);
+    color: white;
+    border-color: var(--primary-purple);
 }
 
 @keyframes confettiFall {


### PR DESCRIPTION
## Summary
- make completionist sublist items easier to tap by switching checkboxes to buttons
- style new sublist buttons
- add total achievement counter in bingo stats

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687811c58b648331914843c20ed66d62