### PR TITLE
Fix mobile header menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                 <button id="menu-toggle" class="md:hidden text-gray-800 focus:outline-none text-2xl">
                     &#9776;
                 </button>
-                <ul id="nav" class="hidden fixed inset-0 nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
+                <ul id="nav" class="hidden fixed nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
                     <li><a href="#bingo" class="tab-link active">Bingo Tracker</a></li>
                     <li><a href="#verse" class="tab-link">Verse of the Hour</a></li>
                     <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -30,6 +30,7 @@ const App = {
                 const nav = document.getElementById('nav');
                 if (nav && (window.innerWidth < 768 || nav.classList.contains('md:hidden'))) {
                     nav.classList.add('hidden');
+                    nav.classList.remove('open');
                 }
             });
         });
@@ -44,7 +45,13 @@ const App = {
         const nav = document.getElementById('nav');
         if (toggle && nav) {
             toggle.addEventListener('click', () => {
-                nav.classList.toggle('hidden');
+                if (nav.classList.contains('hidden')) {
+                    nav.classList.remove('hidden');
+                    nav.classList.add('open');
+                } else {
+                    nav.classList.add('hidden');
+                    nav.classList.remove('open');
+                }
             });
         }
     },

--- a/styles/global.css
+++ b/styles/global.css
@@ -512,24 +512,35 @@ body {
         grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 
-    /* Full-screen mobile navigation */
+    /* Slide-in mobile navigation */
     #nav {
         position: fixed;
-        inset: 0;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 80%;
+        max-width: 16rem;
         display: flex;
         flex-direction: column;
         justify-content: center;
-        align-items: center;
+        align-items: flex-start;
         gap: 1.5rem;
-        padding: 2rem;
+        padding: 2rem 1.5rem;
         background: var(--glass-bg);
         backdrop-filter: blur(20px);
         -webkit-backdrop-filter: blur(20px);
         z-index: 100;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+    }
+
+    #nav.open {
+        transform: translateX(0);
     }
 
     #nav li a {
         font-size: 1.5rem;
         padding: 0.75rem 1rem;
+        width: 100%;
     }
 }


### PR DESCRIPTION
## Summary
- modify nav list to not use inset-0 for slide‑in effect
- add slide-in animation and open state to mobile nav styles
- toggle `open` class from the script when hamburger is pressed
- ensure mobile nav closes after selecting a tab

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687816825db483318d5d09c98f8f5faa