### PR TITLE
Add Terms and Privacy pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ node server.js
 The app will be available at `http://localhost:3000` and the polls API can be
 reached at `http://localhost:3000/api/polls`.
 
+## Legal
+
+Standalone pages [`terms.html`](terms.html) and [`privacy.html`](privacy.html) outline the demo
+Terms of Service and Privacy Policy.
+

--- a/index.html
+++ b/index.html
@@ -107,6 +107,11 @@
         </section>
     </main>
 
+    <footer class="text-center text-gray-600 text-sm py-4">
+        <a href="terms.html" class="hover:underline">Terms of Service</a> |
+        <a href="privacy.html" class="hover:underline">Privacy Policy</a>
+    </footer>
+
     <!-- Load scripts in order -->
     <script src="scripts/utils.js"></script>
     <script src="scripts/storage.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link href="styles/global.css" rel="stylesheet">
+</head>
+<body class="min-h-screen flex flex-col">
+    <header class="mb-4">
+        <nav class="nav-glass shadow-lg">
+            <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+                <a href="index.html" class="text-2xl font-bold text-gray-800">ENDURE 2025</a>
+            </div>
+        </nav>
+    </header>
+    <main class="container mx-auto px-4 pb-8 flex-grow">
+        <div class="glass p-6">
+            <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
+            <p class="text-gray-700 mb-2">This demo app stores minimal data in your browser using local storage for features like bingo progress. Poll data is saved locally on the server when running the optional API. No personal data is collected or shared.</p>
+            <p class="text-gray-700">By using this site you consent to this basic data handling. This policy may change and updates will be posted on this page.</p>
+        </div>
+    </main>
+    <footer class="text-center text-gray-600 text-sm py-4">
+        <a href="terms.html" class="hover:underline">Terms of Service</a> |
+        <a href="privacy.html" class="hover:underline">Privacy Policy</a>
+    </footer>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link href="styles/global.css" rel="stylesheet">
+</head>
+<body class="min-h-screen flex flex-col">
+    <header class="mb-4">
+        <nav class="nav-glass shadow-lg">
+            <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+                <a href="index.html" class="text-2xl font-bold text-gray-800">ENDURE 2025</a>
+            </div>
+        </nav>
+    </header>
+    <main class="container mx-auto px-4 pb-8 flex-grow">
+        <div class="glass p-6">
+            <h1 class="text-3xl font-bold mb-4">Terms of Service</h1>
+            <p class="text-gray-700 mb-2">These terms govern your use of the ENDURE 2025 demo app. By accessing this site you agree to these terms. This project is a simple demonstration and provided as-is for educational purposes only.</p>
+            <p class="text-gray-700">Do not rely on any content for official guidance. We may modify these terms at any time by posting an updated version on this page.</p>
+        </div>
+    </main>
+    <footer class="text-center text-gray-600 text-sm py-4">
+        <a href="terms.html" class="hover:underline">Terms of Service</a> |
+        <a href="privacy.html" class="hover:underline">Privacy Policy</a>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Terms of Service and Privacy Policy pages
- link to new pages from index footer
- mention legal pages in README
- add `.gitignore`

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68781f5ca9e4833191f4aa5f4dfb4426