### PR TITLE
Add Invite Friend sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ both a regular card and a more difficult **completionist** card that can be
 toggled in the interface. Completionist challenges with multiple tasks open in a
 sublist view that can be dismissed via the close button, clicking outside the
 list or pressing <kbd>Esc</kbd>.
+An "Invite a Friend" button lets you quickly share the site link using your
+device's native share sheet or by copying the invite text to the clipboard.
 
 ## File Structure
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
                     <li><a href="#bingo" class="tab-link active">Bingo Tracker</a></li>
                     <li><a href="#verse" class="tab-link">Verse of the Hour</a></li>
                     <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>
+                    <li><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
                 </ul>
             </div>
         </nav>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -9,6 +9,10 @@ const App = {
         
         App.initTabs();
         App.initMenu();
+        const inviteBtn = document.getElementById('invite-btn');
+        if (inviteBtn) {
+            inviteBtn.addEventListener('click', App.inviteFriend);
+        }
         App.initModules();
         App.handleResize();
         
@@ -115,6 +119,21 @@ const App = {
         }, 250);
 
         window.addEventListener('resize', debouncedResize);
+    },
+
+    // Share app link via native share or clipboard
+    inviteFriend: () => {
+        const inviteText = `Check out this Faith Challenge app for the LCMS Youth Gathering! ${window.location.href}`;
+        if (navigator.share) {
+            navigator.share({
+                title: 'GatherTogether Invite',
+                text: inviteText,
+                url: window.location.href
+            }).catch(err => console.error('Share failed', err));
+        } else {
+            navigator.clipboard.writeText(inviteText);
+            Utils.showNotification('Invite link copied to clipboard!');
+        }
     },
 
     // Error handling


### PR DESCRIPTION
## Summary
- add invite friend button to navigation
- handle invite click with native share sheet or clipboard
- document the new invite feature

## Testing
- `npm install` *(fails: none)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68781f8fc9d083319f108faf754343a3