### PR TITLE
Fix invite button reliability

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -122,17 +122,52 @@ const App = {
     },
 
     // Share app link via native share or clipboard
-    inviteFriend: () => {
+    inviteFriend: async () => {
         const inviteText = `Check out this Faith Challenge app for the LCMS Youth Gathering! ${window.location.href}`;
         if (navigator.share) {
-            navigator.share({
-                title: 'GatherTogether Invite',
-                text: inviteText,
-                url: window.location.href
-            }).catch(err => console.error('Share failed', err));
+            try {
+                await navigator.share({
+                    title: 'GatherTogether Invite',
+                    text: inviteText,
+                    url: window.location.href
+                });
+                return;
+            } catch (err) {
+                console.error('Share failed', err);
+                // fall back to copy if share was cancelled or failed
+            }
+        }
+        App.copyInvite(inviteText);
+    },
+
+    copyInvite: (text) => {
+        const fallbackCopy = (str) => {
+            const tempInput = document.createElement('textarea');
+            tempInput.value = str;
+            tempInput.style.position = 'fixed';
+            tempInput.style.top = '-9999px';
+            document.body.appendChild(tempInput);
+            tempInput.focus();
+            tempInput.select();
+            try {
+                document.execCommand('copy');
+                Utils.showNotification('Invite link copied to clipboard!');
+            } catch (err) {
+                console.error('Fallback copy failed', err);
+                Utils.showNotification('Unable to copy invite', 'error');
+            }
+            document.body.removeChild(tempInput);
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text)
+                .then(() => Utils.showNotification('Invite link copied to clipboard!'))
+                .catch(err => {
+                    console.error('Clipboard copy failed', err);
+                    fallbackCopy(text);
+                });
         } else {
-            navigator.clipboard.writeText(inviteText);
-            Utils.showNotification('Invite link copied to clipboard!');
+            fallbackCopy(text);
         }
     },
 


### PR DESCRIPTION
## Summary
- improve App.inviteFriend to fallback to clipboard copy if share fails
- add cross-browser copyInvite helper

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687820e0ca488331888aabe1036c8df6