### PR TITLE
Add Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,14 @@
     "cors": "^2.8.5"
   },
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,9 +3,10 @@ const cors = require('cors');
 const fs = require('fs');
 const path = require('path');
 
-const DATA_PATH = path.join(__dirname, 'data', 'polls.json');
-const RESPONSES_DATA_PATH = path.join(__dirname, 'data', 'poll_responses.json');
-const BINGO_PROGRESS_PATH = path.join(__dirname, 'data', 'bingo_progress.json');
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data');
+const DATA_PATH = path.join(DATA_DIR, 'polls.json');
+const RESPONSES_DATA_PATH = path.join(DATA_DIR, 'poll_responses.json');
+const BINGO_PROGRESS_PATH = path.join(DATA_DIR, 'bingo_progress.json');
 
 const SAMPLE_POLLS = [
   {
@@ -158,7 +159,11 @@ app.get('/api/bingo/leaderboard', (req, res) => {
   res.json(leaderboard);
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+if (require.main === module && module.parent === null) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const request = require('supertest');
+
+let app;
+let tempDir;
+
+beforeEach(() => {
+  jest.resetModules();
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gathertest-'));
+  process.env.DATA_DIR = tempDir;
+  app = require('../server');
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.DATA_DIR;
+  jest.resetModules();
+});
+
+test('GET /api/polls returns poll data', async () => {
+  const res = await request(app).get('/api/polls');
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  expect(res.body.length).toBeGreaterThan(0);
+});
+
+test('POST /api/polls/:pollId/vote stores a vote and returns success', async () => {
+  const pollsRes = await request(app).get('/api/polls');
+  const pollId = pollsRes.body[0].id;
+  const optionId = pollsRes.body[0].options[0].id;
+
+  const res = await request(app)
+    .post(`/api/polls/${pollId}/vote`)
+    .send({ optionId, userId: 'user123' });
+
+  expect(res.status).toBe(201);
+  expect(res.body.message).toBe('Vote recorded');
+
+  const respPath = path.join(tempDir, 'poll_responses.json');
+  expect(fs.existsSync(respPath)).toBe(true);
+  const responses = JSON.parse(fs.readFileSync(respPath, 'utf8'));
+  expect(responses.length).toBe(1);
+  expect(responses[0].pollId).toBe(pollId);
+});
+
+test('Bingo progress endpoints record progress and return leaderboard data', async () => {
+  const progress = { userId: 'u1', username: 'Alice', completedTiles: [1, 2, 3] };
+  const progressRes = await request(app)
+    .post('/api/bingo/progress')
+    .send(progress);
+
+  expect(progressRes.status).toBe(200);
+  expect(progressRes.body.message).toBe('Progress saved');
+
+  const leaderboardRes = await request(app).get('/api/bingo/leaderboard');
+  expect(leaderboardRes.status).toBe(200);
+  expect(Array.isArray(leaderboardRes.body)).toBe(true);
+  expect(leaderboardRes.body[0]).toEqual({
+    username: progress.username,
+    score: progress.completedTiles.length,
+  });
+});


### PR DESCRIPTION
## Summary
- support DATA_DIR environment variable in server
- only start server when run directly
- add Jest and Supertest for testing
- create tests verifying poll and bingo endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687823b2b2688331a32a16a380e94e25