### PR TITLE
Add Invite button to header on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,13 @@
                 <button id="menu-toggle" class="md:hidden text-gray-800 focus:outline-none text-2xl">
                     &#9776;
                 </button>
+                <button id="invite-btn-mobile" class="btn-primary md:hidden ml-2">Invite a Friend</button>
                 <ul id="nav" class="hidden fixed nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
                     <li><a href="#bingo" class="tab-link active">Bingo Tracker</a></li>
                     <li><a href="#verse" class="tab-link">Hourly Verse</a></li>
                     <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>
                     <li><a href="#leaderboard" class="tab-link">Leaderboard</a></li>
-                    <li><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
+                    <li class="hidden md:block"><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
                 </ul>
             </div>
         </nav>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -13,6 +13,10 @@ const App = {
         if (inviteBtn) {
             inviteBtn.addEventListener('click', App.inviteFriend);
         }
+        const inviteBtnMobile = document.getElementById('invite-btn-mobile');
+        if (inviteBtnMobile) {
+            inviteBtnMobile.addEventListener('click', App.inviteFriend);
+        }
         App.initModules();
         App.handleResize();
         


### PR DESCRIPTION
## Summary
- show **Invite a Friend** button in the header when the menu is collapsed on mobile
- attach click handler for mobile invite button

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878286bd8408331922d29d0c85013b5