### PR TITLE
Fix leaderboard username submission

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -405,7 +405,7 @@ const BingoTracker = {
         const userId = Utils.getUserId();
         const username = document.getElementById('username') ? document.getElementById('username').value || 'Anonymous' : 'Anonymous';
         const completedTiles = [...BingoTracker.completedTiles[BingoTracker.currentMode]];
-        fetch('/api/bingo/progress', {
+        return fetch('/api/bingo/progress', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ userId, username, completedTiles })

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -5,6 +5,11 @@ const Leaderboard = {
             usernameInput.value = localStorage.getItem('username') || '';
             usernameInput.addEventListener('change', () => {
                 localStorage.setItem('username', usernameInput.value);
+                if (window.BingoTracker && BingoTracker.saveProgress) {
+                    BingoTracker.saveProgress().then(() => {
+                        Leaderboard.loadLeaderboard();
+                    });
+                }
             });
         }
         Leaderboard.loadLeaderboard();


### PR DESCRIPTION
## Summary
- ensure bingo progress POST returns a promise
- send progress to leaderboard when username field changes

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687829f78c3c8331b4ec8feb480037c2