### PR TITLE
Ensure leaderboard updates correctly

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -409,9 +409,15 @@ const BingoTracker = {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ userId, username, completedTiles })
-        }).catch(err => {
-            console.error('Failed to save progress to server:', err);
-        });
+        })
+            .then(() => {
+                if (typeof Leaderboard !== 'undefined' && App.currentTab === 'leaderboard') {
+                    Leaderboard.loadLeaderboard();
+                }
+            })
+            .catch(err => {
+                console.error('Failed to save progress to server:', err);
+            });
     },
 
     // Load progress

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -62,3 +62,24 @@ test('Bingo progress endpoints record progress and return leaderboard data', asy
     score: progress.completedTiles.length,
   });
 });
+
+test('Leaderboard ranks users and updates existing entries', async () => {
+  // create two users with different scores
+  await request(app)
+    .post('/api/bingo/progress')
+    .send({ userId: 'u1', username: 'User1', completedTiles: [1] });
+  await request(app)
+    .post('/api/bingo/progress')
+    .send({ userId: 'u2', username: 'User2', completedTiles: [1, 2, 3] });
+
+  // update first user with higher score
+  await request(app)
+    .post('/api/bingo/progress')
+    .send({ userId: 'u1', username: 'User1', completedTiles: [1, 2, 3, 4, 5] });
+
+  const res = await request(app).get('/api/bingo/leaderboard');
+  expect(res.status).toBe(200);
+  expect(res.body.length).toBe(2);
+  expect(res.body[0]).toEqual({ username: 'User1', score: 5 });
+  expect(res.body[1]).toEqual({ username: 'User2', score: 3 });
+});


### PR DESCRIPTION
## Summary
- update BingoTracker to refresh leaderboard when progress is saved while viewing the leaderboard
- add test verifying leaderboard ranking and update logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878353da2088331a208655d945d5674