### PR TITLE
Add server status check on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@
 
     <!-- Load scripts in order -->
     <script src="scripts/utils.js"></script>
+    <script src="scripts/serverStatus.js"></script>
     <script src="scripts/storage.js"></script>
     <script src="scripts/bingo.js"></script>
     <script src="scripts/verse.js"></script>

--- a/scripts/serverStatus.js
+++ b/scripts/serverStatus.js
@@ -1,0 +1,20 @@
+const ServerStatus = {
+    check: async () => {
+        try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 3000);
+            const res = await fetch('/api/polls', { signal: controller.signal });
+            clearTimeout(timeout);
+            if (!res.ok) throw new Error('Status ' + res.status);
+        } catch (err) {
+            console.warn('Node server check failed', err);
+            if (window.Utils && Utils.showNotification) {
+                Utils.showNotification('Backend server not running. Start with "npm start".', 'error');
+            }
+        }
+    }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    ServerStatus.check();
+});


### PR DESCRIPTION
## Summary
- show a notification if the backend server isn't running
- include a new script in the page to check server status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68783701a648833181f5d52220f77860