### PR TITLE
Improve leaderboard error messaging

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -417,6 +417,9 @@ const BingoTracker = {
             })
             .catch(err => {
                 console.error('Failed to save progress to server:', err);
+                if (window.Utils && Utils.showNotification) {
+                    Utils.showNotification('Unable to save progress. Is the backend running?', 'error');
+                }
             });
     },
 

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -22,6 +22,9 @@ const Leaderboard = {
             Leaderboard.renderLeaderboard(leaderboard);
         } catch (err) {
             console.error('Failed to load leaderboard:', err);
+            if (window.Utils && Utils.showNotification) {
+                Utils.showNotification('Unable to load leaderboard. Is the backend running?', 'error');
+            }
         }
     },
 


### PR DESCRIPTION
## Summary
- enhance leaderboard error handling with user notifications
- show an error notification if saving bingo progress fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68783a029778833191795a0ca161eec4