### PR TITLE
Update docs for leaderboard backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ GatherTogether/
 
 ## Running the server
 
-The polls feature relies on a small Node.js API. Install dependencies and start
-the server. You can optionally provide `SSL_KEY_PATH` and `SSL_CERT_PATH`
-environment variables to enable HTTPS:
+The polls feature relies on a small Node.js API. The same backend also stores
+progress for the Bingo tracker and serves the leaderboard. Install
+dependencies and start the server. You can optionally provide
+`SSL_KEY_PATH` and `SSL_CERT_PATH` environment variables to enable HTTPS:
 
 ```bash
 npm install
@@ -43,8 +44,9 @@ SSL_CERT_PATH=/path/server.crt npm start
 ```
 
 The app will be available at `http://localhost:3000` (or
-`https://localhost:3000` when using HTTPS) and the polls API can be
-reached at `/api/polls`.
+`https://localhost:3000` when using HTTPS). The polls API is
+accessible at `/api/polls` and the Bingo leaderboard at
+`/api/bingo/leaderboard`.
 
 ## Running Tests
 

--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
                 <div class="text-center mb-6">
                     <h2 class="text-3xl font-bold text-gray-800 mb-2">Bingo Leaderboard</h2>
                     <p class="text-gray-600">See who's leading the Faith Challenge!</p>
+                    <p class="text-gray-600">Scores are saved via the Node.js backend. Make sure it is running.</p>
                 </div>
                 <div class="mb-4">
                     <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>


### PR DESCRIPTION
## Summary
- clarify that leaderboard uses the Node.js backend
- note the leaderboard endpoint in server instructions
- mention in the UI that scores require the backend

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878458ce8d883319d2de74cfbce61bc