### PR TITLE
Add Firebase leaderboard integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,5 +140,35 @@
     <script src="scripts/polls.js"></script>
     <script src="scripts/leaderboard.js"></script>
     <script src="scripts/app.js"></script>
+
+    <!-- Firebase config and initialization -->
+    <script type="module">
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+        import { getFirestore } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+        const firebaseConfig = {
+            apiKey: "YOUR_API_KEY",
+            authDomain: "your-project-id.firebaseapp.com",
+            projectId: "your-project-id",
+            storageBucket: "your-project-id.appspot.com",
+            messagingSenderId: "YOUR_SENDER_ID",
+            appId: "YOUR_APP_ID"
+        };
+
+        const app = initializeApp(firebaseConfig);
+        const db = getFirestore(app);
+        window.firebaseDB = db; // Make it accessible globally
+    </script>
+
+    <script type="module">
+        import { submitScore, getTopScores } from './leaderboard.js';
+
+        const db = window.firebaseDB;
+
+        await submitScore(db, 'tim123', 'Tim', 150);
+
+        const topPlayers = await getTopScores(db);
+        console.log(topPlayers);
+    </script>
 </body>
 </html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,29 @@
+import {
+  collection,
+  getDocs,
+  addDoc,
+  updateDoc,
+  doc,
+  query,
+  orderBy,
+  limit
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+export async function submitScore(db, userId, name, score) {
+  const ref = collection(db, "leaderboard");
+  const snapshot = await getDocs(ref);
+  const match = snapshot.docs.find(d => d.data().userId === userId);
+
+  if (match) {
+    await updateDoc(doc(db, "leaderboard", match.id), { name, score });
+  } else {
+    await addDoc(ref, { userId, name, score });
+  }
+}
+
+export async function getTopScores(db, count = 10) {
+  const ref = collection(db, "leaderboard");
+  const q = query(ref, orderBy("score", "desc"), limit(count));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(doc => doc.data());
+}


### PR DESCRIPTION
## Summary
- add leaderboard module for Firestore
- load Firebase SDK and example usage in `index.html`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687858129260833197882171fbf98f5d