### PR TITLE
Add service account key patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 package-lock.json
+
+# Firebase service account keys
+**/serviceAccountKey.json
+gathertogether-backend/config/serviceAccountKey.json


### PR DESCRIPTION
## Summary
- add Firebase service account key patterns to `.gitignore`

No service account key file was found in the repository, so no removal was necessary.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68786cb4f2008331bf718dae161df66d