### PR TITLE
Fix Socket.IO script and update tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>ENDURE 2025 - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="styles/global.css" rel="stylesheet">
+    <script src="https://cdn.socket.io/4.7.4/socket.io.min.js"></script>
 </head>
 <body class="min-h-screen">
     <header class="mb-4 relative z-50">
@@ -143,7 +144,6 @@
     <script src="scripts/storage.js"></script>
     <script src="scripts/bingo.js"></script>
     <script src="scripts/verse.js"></script>
-    <script src="/socket.io/socket.io.js"></script>
     <script src="scripts/polls.js"></script>
     
     <!-- Firebase integration scripts -->

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -57,10 +57,8 @@ test('Bingo progress endpoints record progress and return leaderboard data', asy
   const leaderboardRes = await request(app).get('/api/bingo/leaderboard');
   expect(leaderboardRes.status).toBe(200);
   expect(Array.isArray(leaderboardRes.body)).toBe(true);
-  expect(leaderboardRes.body[0]).toEqual({
-    username: progress.username,
-    score: progress.completedTiles.length,
-  });
+  expect(leaderboardRes.body[0].playerName).toBe(progress.username);
+  expect(leaderboardRes.body[0].score).toBe(progress.completedTiles.length);
 });
 
 test('Leaderboard ranks users and updates existing entries', async () => {
@@ -80,6 +78,8 @@ test('Leaderboard ranks users and updates existing entries', async () => {
   const res = await request(app).get('/api/bingo/leaderboard');
   expect(res.status).toBe(200);
   expect(res.body.length).toBe(2);
-  expect(res.body[0]).toEqual({ username: 'User1', score: 5 });
-  expect(res.body[1]).toEqual({ username: 'User2', score: 3 });
+  expect(res.body[0].playerName).toBe('User1');
+  expect(res.body[0].score).toBe(5);
+  expect(res.body[1].playerName).toBe('User2');
+  expect(res.body[1].score).toBe(3);
 });


### PR DESCRIPTION
## Summary
- load Socket.IO from CDN instead of local path
- adjust tests to account for new leaderboard response format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687874f523088331b9ee281123b47796