### PR TITLE
Enable sublist country entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ vanilla JavaScript without external frameworks. The bingo tracker now supports
 both a regular card and a more difficult **completionist** card that can be
 toggled in the interface. Completionist challenges with multiple tasks open in a
 sublist view that can be dismissed via the close button, clicking outside the
-list or pressing <kbd>Esc</kbd>.
+list or pressing <kbd>Esc</kbd>. For sublists with numbered placeholders such as
+"Meet people from 5 different countries," tapping a placeholder lets you enter
+the actual item name so each country can be recorded individually.
 An "Invite a Friend" button lets you quickly share the site link using your
 device's native share sheet or by copying the invite text to the clipboard.
 

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -35,7 +35,7 @@ const US_STATES = [
 
 const COMPLETIONIST_CHALLENGES = [
     { text: 'Meet someone from all 50 states', sublist: US_STATES },
-    { text: 'Meet people from 5 different countries', sublist: Array.from({length:5},(_,i)=>`Country ${i+1}`) },
+    { text: 'Meet people from 5 different countries', sublist: Array.from({length:5},(_,i)=>`Country ${i+1}`), freeText: true },
     { text: 'Collect all district booth prizes', sublist: Array.from({length:10},(_,i)=>`Prize ${i+1}`) },
     { text: 'Compete in every convention center game', sublist: Array.from({length:8},(_,i)=>`Game ${i+1}`) },
     { text: 'Attend 15+ sessions/workshops', sublist: Array.from({length:15},(_,i)=>`Session ${i+1}`), freeText: true },


### PR DESCRIPTION
## Summary
- allow entering country names for the completionist challenge
- document how numbered sublists work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687883227170833197cec2fde4c31eed