### PR TITLE
Implement user info storage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,22 @@ npm start
 ```
 
 The local server will serve the app at `http://localhost:3000` and expose the
-`/api/polls` and `/api/bingo/leaderboard` endpoints.
+`/api/polls`, `/api/bingo/leaderboard` and `/api/users` endpoints. The
+`/api/users` route lets you save simple profile information (user ID,
+username and email) to `data/users.json`.
+
+### Hosting on WordPress
+
+If you only have static hosting such as a WordPress.com site, deploy the
+frontend files (`index.html`, `styles/`, `scripts/`) to your WordPress media
+library or theme and embed the page via `<iframe>`:
+
+```html
+<iframe src="https://your-node-backend.example.com/index.html" width="100%" height="800"></iframe>
+```
+
+Run the Node server on a separate host (e.g. Render or Fly.io) and set the
+`FRONTEND_URL` environment variable so CORS allows your WordPress domain.
 
 ## Running Tests
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -83,3 +83,18 @@ test('Leaderboard ranks users and updates existing entries', async () => {
   expect(res.body[1].playerName).toBe('User2');
   expect(res.body[1].score).toBe(3);
 });
+
+test('POST /api/users stores user info and can be retrieved', async () => {
+  const user = { userId: 'user42', username: 'Tester', email: 't@example.com' };
+  const res = await request(app)
+    .post('/api/users')
+    .send(user);
+
+  expect(res.status).toBe(200);
+  expect(res.body.message).toBe('User info saved');
+
+  const getRes = await request(app).get('/api/users/user42');
+  expect(getRes.status).toBe(200);
+  expect(getRes.body.username).toBe('Tester');
+  expect(getRes.body.email).toBe('t@example.com');
+});


### PR DESCRIPTION
## Summary
- add JSON storage for users on the local server
- expose `/api/users` endpoints
- test the new API route
- document how to host the frontend on WordPress via an iframe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788ab9826c83318b9b9215c6cc155e