### PR TITLE
Add total points summary to bingo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
                     <p class="text-gray-600">Complete challenges to grow in faith during the gathering!</p>
                 </div>
 
+                <div class="total-points">
+                    Total Points: <span id="total-points">0</span>
+                </div>
+
                 <div class="card-selector">
                     <button class="card-type-btn active" data-type="regular">🎯 Regular</button>
                     <button class="card-type-btn completionist" data-type="completionist">🏆 Completionist</button>

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -415,7 +415,8 @@ const BingoTracker = {
             'completed-count': completedCount,
             'progress-percent': progressPercent + '%',
             'bingo-count': bingoLines,
-            'achievement-count': achievements
+            'achievement-count': achievements,
+            'total-points': achievements
         };
         
         Object.entries(elements).forEach(([id, value]) => {

--- a/styles/global.css
+++ b/styles/global.css
@@ -197,6 +197,14 @@ body {
     margin-bottom: 2rem;
 }
 
+.total-points {
+    text-align: center;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--primary-purple);
+    margin-bottom: 1rem;
+}
+
 .card-type-btn {
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- show total points at the top of the Bingo section
- style the points display
- update BingoTracker to refresh the total points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788c44285c8331af5dab502230a8f4