### PR TITLE
Add optional Google Sheets backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ development provide a Firebase service account file at
 set environment variables such as `FIREBASE_PROJECT_ID`, `FIREBASE_PRIVATE_KEY`
 and `FIREBASE_CLIENT_EMAIL` instead.
 
+### Google Sheets backend (optional)
+
+If you prefer not to use Firebase, set `GOOGLE_SHEETS_ID`,
+`GOOGLE_SHEETS_CLIENT_EMAIL` and `GOOGLE_SHEETS_PRIVATE_KEY` when starting the
+backend. When these variables are present the server stores leaderboard rows in
+a Google Sheet using the Sheets API. Install dependencies in the backend folder
+with `npm install` before running.
+
 ### Local server.js (optional)
 
 The original `server.js` at the repository root stores data in JSON files and

--- a/gathertogether-backend/config/googleSheets.js
+++ b/gathertogether-backend/config/googleSheets.js
@@ -1,0 +1,33 @@
+const { google } = require('googleapis');
+
+let sheetsClient;
+
+async function getSheetsClient() {
+  if (sheetsClient) return sheetsClient;
+
+  const required = [
+    'GOOGLE_SHEETS_CLIENT_EMAIL',
+    'GOOGLE_SHEETS_PRIVATE_KEY',
+    'GOOGLE_SHEETS_ID',
+  ];
+  const missing = required.filter(v => !process.env[v]);
+  if (missing.length) {
+    throw new Error(`Missing Google Sheets configuration: ${missing.join(', ')}`);
+  }
+
+  const auth = new google.auth.GoogleAuth({
+    credentials: {
+      client_email: process.env.GOOGLE_SHEETS_CLIENT_EMAIL,
+      private_key: process.env.GOOGLE_SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n'),
+    },
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+
+  const authClient = await auth.getClient();
+  sheetsClient = google.sheets({ version: 'v4', auth: authClient });
+  return sheetsClient;
+}
+
+const spreadsheetId = process.env.GOOGLE_SHEETS_ID;
+
+module.exports = { getSheetsClient, spreadsheetId };

--- a/gathertogether-backend/package.json
+++ b/gathertogether-backend/package.json
@@ -18,7 +18,8 @@
     "express": "^5.1.0",
     "firebase-admin": "^13.4.0",
     "helmet": "^8.1.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "googleapis": "^132.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/gathertogether-backend/routes/bingo.js
+++ b/gathertogether-backend/routes/bingo.js
@@ -1,10 +1,27 @@
 const express = require('express');
 const router = express.Router();
 const { db, admin } = require('../config/firebase');
+const { getSheetsClient, spreadsheetId } = require('../config/googleSheets');
+
+const useSheets = !!process.env.GOOGLE_SHEETS_ID;
 
 // Get leaderboard
 router.get('/leaderboard', async (req, res) => {
   try {
+    if (useSheets) {
+      const sheets = await getSheetsClient();
+      const result = await sheets.spreadsheets.values.get({
+        spreadsheetId,
+        range: 'Leaderboard!A2:C',
+      });
+      const rows = result.data.values || [];
+      const leaderboard = rows
+        .map(r => ({ id: r[0], playerName: r[1], score: parseInt(r[2], 10) || 0 }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 50);
+      return res.json(leaderboard);
+    }
+
     const leaderboardSnapshot = await db
       .collection('bingo_leaderboard')
       .orderBy('score', 'desc')
@@ -30,6 +47,33 @@ router.get('/leaderboard', async (req, res) => {
 router.post('/leaderboard', async (req, res) => {
   try {
     const { playerId, playerName, score } = req.body;
+    if (useSheets) {
+      const sheets = await getSheetsClient();
+      const result = await sheets.spreadsheets.values.get({
+        spreadsheetId,
+        range: 'Leaderboard!A2:C',
+      });
+      const rows = result.data.values || [];
+      let rowIndex = rows.findIndex(r => r[0] === playerId);
+      if (rowIndex === -1) {
+        await sheets.spreadsheets.values.append({
+          spreadsheetId,
+          range: 'Leaderboard!A2:C',
+          valueInputOption: 'RAW',
+          insertDataOption: 'INSERT_ROWS',
+          resource: { values: [[playerId, playerName, score]] },
+        });
+      } else {
+        rowIndex += 2;
+        await sheets.spreadsheets.values.update({
+          spreadsheetId,
+          range: `Leaderboard!A${rowIndex}:C${rowIndex}`,
+          valueInputOption: 'RAW',
+          resource: { values: [[playerId, playerName, score]] },
+        });
+      }
+      return res.json({ message: 'Score updated successfully' });
+    }
 
     const playerRef = db.collection('bingo_leaderboard').doc(playerId);
 


### PR DESCRIPTION
## Summary
- allow storing leaderboard data in Google Sheets
- include Google Sheets config and helper
- document new backend option in README
- add `googleapis` dependency

## Testing
- `npm install`
- `cd gathertogether-backend && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68788c84c4c48331834ed5a76c0268f4