### PR TITLE
Remove unused Socket.IO setup hooks

### DIFF
--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -66,6 +66,11 @@ const Leaderboard = {
         }
     },
 
+    setupSocket: () => {
+        // Socket.IO disabled for static hosting
+        console.log('Using Firebase real-time updates instead of Socket.IO');
+    },
+
     loadLeaderboard: async () => {
         if (Leaderboard.firebaseLeaderboard && Leaderboard.firebaseLeaderboard.isAvailable()) {
             try {

--- a/scripts/polls.js
+++ b/scripts/polls.js
@@ -170,7 +170,7 @@ const PollManager = {
         if (!poll) return null;
 
         const totalVotes = poll.options.reduce((sum, option) => sum + option.votes, 0);
-        
+
         return {
             ...poll,
             totalVotes,
@@ -179,6 +179,11 @@ const PollManager = {
                 percentage: totalVotes > 0 ? Math.round((option.votes / totalVotes) * 100) : 0
             }))
         };
+    },
+
+    setupSocket: () => {
+        // Socket.IO disabled for static hosting
+        console.log('Real-time updates via Socket.IO disabled (static hosting)');
     },
 
     // Future: Submit Q&A question


### PR DESCRIPTION
## Summary
- add no-op `setupSocket` methods in `polls.js` and `leaderboard.js`
- confirm Socket.IO script not loaded in `index.html`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ebc6b9188331bc892633647687a5