### PR TITLE
Fix Firestore init

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@
 
             // Make Firestore modules available globally
             window.firestoreModules = {
+                getFirestore,
                 collection,
                 addDoc,
                 updateDoc,

--- a/scripts/firebase-leaderboard.js
+++ b/scripts/firebase-leaderboard.js
@@ -10,11 +10,12 @@ class FirebaseLeaderboard {
     // Initialize Firebase connection
     async init(firebaseApp) {
         try {
-            if (typeof getFirestore === 'undefined') {
+            if (!window.firestoreModules || typeof window.firestoreModules.getFirestore === 'undefined') {
                 console.warn('Firebase Firestore not available');
                 return false;
             }
 
+            const { getFirestore } = window.firestoreModules;
             this.db = getFirestore(firebaseApp);
             this.initialized = true;
             console.log('Firebase Leaderboard initialized successfully');


### PR DESCRIPTION
## Summary
- expose `getFirestore` globally with other Firestore helpers
- update `FirebaseLeaderboard` to use the exported function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ee6377188331973a4f098206e7b5