### PR TITLE
Initialize leaderboard on page load

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -98,7 +98,7 @@ const App = {
                 // Polls are initialized on app load
                 break;
             case 'leaderboard':
-                Leaderboard.init();
+                Leaderboard.refresh();
                 break;
         }
     },
@@ -110,7 +110,8 @@ const App = {
             await Promise.all([
                 BingoTracker.init(),
                 VerseManager.init(),
-                PollManager.init()
+                PollManager.init(),
+                Leaderboard.init()
             ]);
         } catch (error) {
             console.error('Error initializing modules:', error);


### PR DESCRIPTION
## Summary
- refresh leaderboard when switching to the leaderboard tab
- start the leaderboard module as part of the app startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f2bfa42c83319646f3eda8b01042