### PR TITLE
Prevent leaderboard double initialization

### DIFF
--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -1,7 +1,10 @@
 const Leaderboard = {
     firebaseLeaderboard: null,
+    isInitialized: false,
 
     init: async () => {
+        if (Leaderboard.isInitialized) return;
+        Leaderboard.isInitialized = true;
         console.log('🚀 Initializing Leaderboard...');
 
         // Wait for Firebase to be ready


### PR DESCRIPTION
## Summary
- add an `isInitialized` flag to `Leaderboard` to guard against multiple inits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f2b30db08331a042bb4b1330b8a3