### PR TITLE
Initialize Leaderboard earlier

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -106,12 +106,16 @@ const App = {
     // Initialize all modules
     initModules: async () => {
         try {
-            // Initialize modules in parallel
+            // Initialize Leaderboard first to ensure its initialization promise
+            // is available for other modules.
+            // This call is synchronous and kicks off the async setup work.
+            Leaderboard.init();
+
+            // Initialize other modules in parallel.
             await Promise.all([
                 BingoTracker.init(),
                 VerseManager.init(),
-                PollManager.init(),
-                Leaderboard.init()
+                PollManager.init()
             ]);
         } catch (error) {
             console.error('Error initializing modules:', error);


### PR DESCRIPTION
## Summary
- make sure `Leaderboard.init()` runs before other modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f7c65bb8833196925ac854264640