### PR TITLE
Wait for Firebase initialization before saving Bingo scores

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -448,6 +448,8 @@ const BingoTracker = {
 
         if (score > 0 && window.Leaderboard && typeof Leaderboard.saveScore === 'function') {
             try {
+                // Ensure Firebase is ready before attempting to save
+                await Leaderboard.initializationPromise;
                 await Leaderboard.saveScore(userId, username, score);
                 console.log('✅ Progress saved to leaderboard');
             } catch (error) {


### PR DESCRIPTION
## Summary
- ensure BingoTracker waits for Leaderboard to initialize before saving scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fb077f4483319b52c9609b479498