### PR TITLE
Fix leaderboard init race and add bingo loading state

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,9 @@
                 </div>
 
                 <div class="bingo-grid regular mb-6" id="bingo-grid">
+                    <div class="loading-overlay">
+                        <p>Loading Bingo Board...</p>
+                    </div>
                     <!-- Bingo tiles will be generated here -->
                 </div>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -106,17 +106,22 @@ const App = {
     // Initialize all modules
     initModules: async () => {
         try {
-            // Initialize Leaderboard first to ensure its initialization promise
-            // is available for other modules.
-            // This call is synchronous and kicks off the async setup work.
+            // Initialize the leaderboard first and wait for Firebase to connect
             Leaderboard.init();
+            await Leaderboard.initializationPromise;
 
-            // Initialize other modules in parallel.
+            // Once the leaderboard is ready, initialize the other modules
             await Promise.all([
                 BingoTracker.init(),
                 VerseManager.init(),
                 PollManager.init()
             ]);
+
+            // Remove loading overlay and enable the bingo board
+            const bingoGrid = document.getElementById('bingo-grid');
+            if (bingoGrid) {
+                bingoGrid.classList.add('loaded');
+            }
         } catch (error) {
             console.error('Error initializing modules:', error);
             Utils.showNotification('Some features may not work properly', 'error');

--- a/styles/global.css
+++ b/styles/global.css
@@ -92,6 +92,26 @@ body {
     gap: 0.5rem;
     max-width: 600px;
     margin: 0 auto;
+    position: relative;
+}
+
+.bingo-grid .loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: #333;
+    z-index: 10;
+}
+
+.bingo-grid.loaded .loading-overlay {
+    display: none;
 }
 
 .bingo-grid.regular {


### PR DESCRIPTION
## Summary
- add loading overlay in bingo grid
- style loading overlay to block interactions
- wait for leaderboard initialization before enabling bingo grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fc46d1c88331b880d481db9a7e02