### PR TITLE
Enable global loading overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="styles/global.css" rel="stylesheet">
 </head>
-<body class="min-h-screen">
+<body class="min-h-screen app-loading">
     <header class="mb-4 relative z-50">
         <nav class="nav-glass shadow-lg">
             <div class="container relative mx-auto px-4 py-4 flex justify-between items-center">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -106,25 +106,31 @@ const App = {
     // Initialize all modules
     initModules: async () => {
         try {
-            // Initialize the leaderboard first and wait for Firebase to connect
+            console.log("Starting module initialization...");
+
+            // Initialize Leaderboard and wait for Firebase to be ready.
             Leaderboard.init();
             await Leaderboard.initializationPromise;
+            console.log("Firebase and Leaderboard initialized.");
 
-            // Once the leaderboard is ready, initialize the other modules
+            // Now initialize all other modules that might depend on Firebase/Leaderboard.
             await Promise.all([
                 BingoTracker.init(),
                 VerseManager.init(),
                 PollManager.init()
             ]);
+            console.log("All modules initialized.");
 
-            // Remove loading overlay and enable the bingo board
-            const bingoGrid = document.getElementById('bingo-grid');
-            if (bingoGrid) {
-                bingoGrid.classList.add('loaded');
-            }
+            // Everything is ready. Enable the UI by removing the loading class from the body.
+            document.body.classList.remove('app-loading');
+            console.log('App is fully loaded and interactive.');
+
         } catch (error) {
             console.error('Error initializing modules:', error);
             Utils.showNotification('Some features may not work properly', 'error');
+            // If an error occurs, we should still remove the loading state
+            // to not leave the user with a perpetually disabled UI.
+            document.body.classList.remove('app-loading');
         }
     },
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -93,8 +93,10 @@ body {
     max-width: 600px;
     margin: 0 auto;
     position: relative;
+    min-height: 400px; /* Ensure grid has height during load */
 }
 
+/* Hide loading overlay by default */
 .bingo-grid .loading-overlay {
     position: absolute;
     top: 0;
@@ -102,7 +104,7 @@ body {
     right: 0;
     bottom: 0;
     background: rgba(255, 255, 255, 0.8);
-    display: flex;
+    display: none; /* Hidden by default */
     align-items: center;
     justify-content: center;
     font-size: 1.2rem;
@@ -110,9 +112,16 @@ body {
     z-index: 10;
 }
 
-.bingo-grid.loaded .loading-overlay {
-    display: none;
+/* --- NEW RULES FOR LOADING STATE --- */
+.app-loading #bingo-grid {
+    pointer-events: none; /* Disable all clicks on the board */
+    opacity: 0.6;
 }
+
+.app-loading #bingo-grid .loading-overlay {
+    display: flex; /* Show the overlay when the app is loading */
+}
+/* --- END OF NEW RULES --- */
 
 .bingo-grid.regular {
     grid-template-columns: repeat(5, 1fr);


### PR DESCRIPTION
## Summary
- add `app-loading` class to `<body>` so UI starts disabled
- show bingo loading overlay when the page has `app-loading`
- update `initModules` to remove the loading class once ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ff6c439c8331847ae11ea123b722