### PR TITLE
Fix bingo loading overlay display

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -107,7 +107,14 @@ const BingoTracker = {
         const grid = document.getElementById('bingo-grid');
         if (!grid) return;
 
+        // Preserve the loading overlay if it exists so that we can
+        // show it while the application is initializing. Clearing
+        // innerHTML would remove it, so reattach after the reset.
+        const overlay = grid.querySelector('.loading-overlay');
         grid.innerHTML = '';
+        if (overlay) {
+            grid.appendChild(overlay);
+        }
 
         const challenges = BingoTracker.getCurrentChallenges();
         const completedSet = BingoTracker.completedTiles[BingoTracker.currentMode];


### PR DESCRIPTION
## Summary
- preserve the loading overlay when rendering the bingo grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687900c3b7ac8331b18083449218d8bb