### PR TITLE
Fix: Prevent crash when ServerStatus is undefined in App.init

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5,7 +5,9 @@ const App = {
     init: async () => {
         // Initialize all modules
         App.setupEventListeners();
-        ServerStatus.init();
+        if (typeof ServerStatus !== 'undefined' && typeof ServerStatus.init === 'function') {
+            ServerStatus.init();
+        }
         BingoTracker.init();
         VerseManager.init();
         Polls.init();


### PR DESCRIPTION
## Summary
- check for `ServerStatus.init` before calling it in `App.init`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687909d8e8688331b0d1419fd7aab140