### PR TITLE
Fix Firebase leaderboard initialization

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -11,11 +11,11 @@ const App = {
         BingoTracker.init();
         VerseManager.init();
         PollManager.init(); // This is the corrected line
-        leaderboard.init();
+        Leaderboard.init();
 
         try {
             // Wait for critical initializations to complete
-            await leaderboard.initializationPromise;
+            await Leaderboard.initializationPromise;
             
             // --- NEW: Enforce a minimum display time for the loader ---
             // This ensures the loader is visible for at least a moment, preventing a jarring flash.

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -272,6 +272,9 @@ const Leaderboard = {
     }
 };
 
+// Expose globally for other modules
+window.Leaderboard = Leaderboard;
+
 // Auto-refresh when tab becomes visible again
 document.addEventListener('visibilitychange', () => {
     if (!document.hidden && App && App.currentTab === 'leaderboard') {


### PR DESCRIPTION
## Summary
- fix initialization call in `app.js`
- expose `Leaderboard` globally for other modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879199788b88331a5404e597f4f2793