### PR TITLE
Handle pending leaderboard scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ leaderboard is stored directly in Firebase **Firestore** from the browser.
 Simply open `index.html` or visit the live GitHub Pages site and the app
 will connect to Firebase without any additional server setup.
 
+Any scores recorded before Firebase initializes are queued locally and will be
+automatically submitted once the connection becomes available.
+
 If you want to use your own Firebase project, edit the `firebaseConfig`
 object at the bottom of `index.html` with your project credentials.
 

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -65,6 +65,8 @@ const Leaderboard = {
 
                 // Resolve the initialization promise
                 Leaderboard._resolveInitialization();
+                // Flush any scores that were queued before Firebase was ready
+                Leaderboard.flushPendingScores();
                 console.log('✅ Leaderboard is ready for use.');
 
             } else {
@@ -79,6 +81,8 @@ const Leaderboard = {
             if (App.currentTab === 'leaderboard') {
                 Leaderboard.showError('Failed to connect to Firebase. Check console for details.');
             }
+            // Resolve the initialization promise even on failure
+            Leaderboard._resolveInitialization();
         }
     },
 


### PR DESCRIPTION
## Summary
- flush queued leaderboard scores once Firebase is initialized
- always resolve the leaderboard initialization promise
- note that scores are queued until Firebase connects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791d949d788331a2bcdb81c41d2ac3