### PR TITLE
Persist leaderboard score even at zero

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -325,7 +325,8 @@ const BingoTracker = {
         const username = usernameInput ? usernameInput.value || 'Anonymous' : 'Anonymous';
         const score = BingoTracker.countAchievements();
 
-        if (score > 0 && window.Leaderboard && typeof Leaderboard.saveScore === 'function') {
+        // Always save score so a user can reset their leaderboard entry to zero
+        if (window.Leaderboard && typeof Leaderboard.saveScore === 'function') {
             try {
                 // Ensure Firebase is ready before attempting to save
                 await Leaderboard.initializationPromise;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -109,3 +109,19 @@ test('GET /api/bingo/lines/:userId returns line count', async () => {
   expect(res.status).toBe(200);
   expect(res.body.lines).toBe(3);
 });
+
+test('Submitting zero completed tiles resets leaderboard score', async () => {
+  await request(app)
+    .post('/api/bingo/progress')
+    .send({ userId: 'resetUser', username: 'Reset', completedTiles: [1, 2] });
+
+  await request(app)
+    .post('/api/bingo/progress')
+    .send({ userId: 'resetUser', username: 'Reset', completedTiles: [] });
+
+  const res = await request(app).get('/api/bingo/leaderboard');
+  expect(res.status).toBe(200);
+  const entry = res.body.find(e => e.playerName === 'Reset');
+  expect(entry).toBeTruthy();
+  expect(entry.score).toBe(0);
+});


### PR DESCRIPTION
## Summary
- allow saving a score of `0` from the bingo tracker so users can reset their leaderboard entry
- cover score reset behavior in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791d99d34083319e71373258f9fce1