### PR TITLE
Update completionist challenge for main speakers

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -50,7 +50,7 @@ const COMPLETIONIST_CHALLENGES = [
     { text: 'Share testimony in 3 different venues', sublist: Array.from({length:3},(_,i)=>`Venue ${i+1}`), freeText: true },
     { text: 'Complete daily random acts of kindness', sublist: Array.from({length:7},(_,i)=>`Day ${i+1}`), freeText: true },
     { text: 'Fast for a meal and donate savings' },
-    { text: 'Get photos with all main speakers', sublist: ['Shelly Schwalm', 'Tanner Olsen', 'Brady Finnern'], freeText: true },
+    { text: 'Get photos with all main speakers', sublist: ['Shelly Schwalm', 'Tanner Olsen', 'Brady Finnern'] },
     { text: 'Visit every exhibitor booth', sublist: Array.from({length:50},(_,i)=>`Booth ${i+1}`) },
     { text: 'Attend all main sessions', sublist: ['Opening', 'Session 1', 'Session 2', 'etc.'], freeText: true }
 ];


### PR DESCRIPTION
## Summary
- remove freeText from "Get photos with all main speakers" so it's checkbox-based

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879211555988331b3047d6485180663