### PR TITLE
Load sessions from JSON and add search

### DIFF
--- a/data/sessions.json
+++ b/data/sessions.json
@@ -1,0 +1,17 @@
+[
+  "Opening Keynote: Enduring Faith",
+  "Workshop: Sharing the Gospel Online",
+  "Seminar: Serving Your Community",
+  "Panel: Youth Leadership Roundtable",
+  "Workshop: Faith and Mental Health",
+  "Session: Mission Opportunities",
+  "Workshop: Building Inclusive Ministries",
+  "Panel: Q&A with Guest Speakers",
+  "Workshop: Leading Worship with Music",
+  "Session: Engaging Bible Study",
+  "Workshop: Social Media for Ministry",
+  "Seminar: Navigating College Life",
+  "Session: Developing Daily Devotions",
+  "Workshop: Discipleship Small Groups",
+  "Closing Rally: Go and Tell"
+]

--- a/styles/global.css
+++ b/styles/global.css
@@ -447,6 +447,16 @@ body {
     background: rgba(124,58,237,0.1);
 }
 
+.sublist-search {
+    display: block;
+    width: 100%;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+}
+
 .sub-item-btn:hover {
     background: rgba(124,58,237,0.1);
     border-color: var(--primary-purple);


### PR DESCRIPTION
## Summary
- add `data/sessions.json` with deduplicated session list
- load sessions from JSON in bingo challenge
- show required count in completionist grid
- add search field for selecting sessions
- style `sublist-search`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687922caa0008331a81a40ca7d5e4ef6