### PR TITLE
Change default tab to leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
                     </button>
                     <button id="invite-btn-mobile" class="btn-primary md:hidden ml-2">Invite a Friend</button>
                     <ul id="nav" class="hidden fixed nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
-                        <li><a href="#bingo" class="tab-link active">Challenge Tracker</a></li>
+                        <li><a href="#leaderboard" class="tab-link active">Leaderboard</a></li>
+                        <li><a href="#bingo" class="tab-link">Challenge Tracker</a></li>
                         <li><a href="#verse" class="tab-link">Hourly Verse</a></li>
                         <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>
-                        <li><a href="#leaderboard" class="tab-link">Leaderboard</a></li>
                         <li class="hidden md:block"><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
                     </ul>
                 </div>
@@ -38,7 +38,7 @@
         </header>
 
         <main class="container mx-auto px-4 pb-8">
-            <section id="bingo" class="tab-section">
+            <section id="bingo" class="tab-section hidden">
                 <div class="glass p-6">
                     <div class="text-center mb-6">
                         <h2 class="text-3xl font-bold text-gray-800 mb-2">Faith Challenges</h2>
@@ -111,7 +111,7 @@
                 </div>
             </section>
 
-            <section id="leaderboard" class="tab-section hidden">
+            <section id="leaderboard" class="tab-section">
                 <div class="glass p-6">
                     <div class="text-center mb-6">
                         <h2 class="text-3xl font-bold text-gray-800 mb-2">Challenge Leaderboard</h2>
@@ -127,9 +127,10 @@
                         <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
                     </div>
                     <ul id="leaderboard-list" class="space-y-2"></ul>
-                    <div class="text-center mt-4">
+                    <div class="text-center mt-4 space-x-2">
                         <button id="submit-score-btn" onclick="Leaderboard.saveCurrentProgress()" class="btn-primary">Submit Score</button>
                         <button onclick="Leaderboard.refresh()" class="btn-secondary">Refresh Leaderboard</button>
+                        <button onclick="document.querySelector('a[href=\'#bingo\']').click()" class="btn-secondary">Start Challenges</button>
                     </div>
                 </div>
             </section>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,6 +1,7 @@
 // Main application logic
 
 const App = {
+    currentTab: null,
     // Initialize the application
     init: async () => {
         // Initialize all modules
@@ -40,6 +41,10 @@ const App = {
     setupEventListeners: () => {
         const tabLinks = document.querySelectorAll('.tab-link');
         const tabSections = document.querySelectorAll('.tab-section');
+        const activeLink = document.querySelector('.tab-link.active');
+        if (activeLink) {
+            App.currentTab = activeLink.getAttribute('href').substring(1);
+        }
         const menuToggle = document.getElementById('menu-toggle');
         const nav = document.getElementById('nav');
 
@@ -48,6 +53,7 @@ const App = {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
                 const targetId = link.getAttribute('href').substring(1);
+                App.currentTab = targetId;
                 
                 tabSections.forEach(section => {
                     section.classList.toggle('hidden', section.id !== targetId);


### PR DESCRIPTION
## Summary
- show the leaderboard first so users pick a username before viewing challenges
- keep track of the current tab for the app
- add a quick link from the leaderboard to the challenge tracker

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792407427883319a21357b2ddaad16