### PR TITLE
Move leaderboard to button

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                         <li><a href="#bingo" class="tab-link active">Challenge Tracker</a></li>
                         <li><a href="#verse" class="tab-link">Hourly Verse</a></li>
                         <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>
-                        <li><a href="#leaderboard" class="tab-link">Leaderboard</a></li>
+                        <!-- Leaderboard tab removed in favor of in-page button -->
                         <li class="hidden md:block"><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
                     </ul>
                 </div>
@@ -50,6 +50,7 @@
                     </div>
 
                     <div class="card-selector">
+                        <button id="open-leaderboard-btn" class="btn-secondary">🏅 Leaderboard</button>
                         <button class="card-type-btn active" data-type="regular">🎯 Regular</button>
                         <button class="card-type-btn completionist" data-type="completionist">🏆 Completionist</button>
                     </div>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,6 +1,23 @@
 // Main application logic
 
 const App = {
+    currentTab: 'bingo',
+    
+    switchTab: (targetId) => {
+        const tabLinks = document.querySelectorAll('.tab-link');
+        const tabSections = document.querySelectorAll('.tab-section');
+
+        tabSections.forEach(section => {
+            section.classList.toggle('hidden', section.id !== targetId);
+        });
+
+        tabLinks.forEach(l => {
+            const linkTarget = l.getAttribute('href').substring(1);
+            l.classList.toggle('active', linkTarget === targetId);
+        });
+
+        App.currentTab = targetId;
+    },
     // Initialize the application
     init: async () => {
         // Initialize all modules
@@ -48,13 +65,7 @@ const App = {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
                 const targetId = link.getAttribute('href').substring(1);
-                
-                tabSections.forEach(section => {
-                    section.classList.toggle('hidden', section.id !== targetId);
-                });
-
-                tabLinks.forEach(l => l.classList.remove('active'));
-                link.classList.add('active');
+                App.switchTab(targetId);
 
                 // Close mobile menu on navigation
                 if (nav.classList.contains('open')) {
@@ -62,6 +73,14 @@ const App = {
                 }
             });
         });
+
+        // Leaderboard button within bingo section
+        const openLbBtn = document.getElementById('open-leaderboard-btn');
+        if (openLbBtn) {
+            openLbBtn.addEventListener('click', () => {
+                App.switchTab('leaderboard');
+            });
+        }
 
         // Mobile menu toggle
         menuToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- drop leaderboard item from nav
- add `Leaderboard` button near the card-type selector
- track current tab in the app and implement `switchTab`
- hook new button to open the leaderboard

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879247167bc833186c01bf91bc5eea1