### PR TITLE
Move leaderboard button to bingo area

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,7 @@
                     </button>
                     <button id="invite-btn-mobile" class="btn-primary md:hidden ml-2">Invite a Friend</button>
                     <ul id="nav" class="hidden fixed nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
-                        <li><a href="#leaderboard" class="tab-link active">Leaderboard</a></li>
-                        <li><a href="#bingo" class="tab-link">Challenge Tracker</a></li>
+                        <li><a href="#bingo" class="tab-link active">Challenge Tracker</a></li>
                         <li><a href="#verse" class="tab-link">Hourly Verse</a></li>
                         <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>
                         <li class="hidden md:block"><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
@@ -38,7 +37,7 @@
         </header>
 
         <main class="container mx-auto px-4 pb-8">
-            <section id="bingo" class="tab-section hidden">
+            <section id="bingo" class="tab-section">
                 <div class="glass p-6">
                     <div class="text-center mb-6">
                         <h2 class="text-3xl font-bold text-gray-800 mb-2">Faith Challenges</h2>
@@ -50,6 +49,7 @@
                     </div>
 
                     <div class="card-selector">
+                        <button id="leaderboard-btn" class="card-type-btn">🏅 Leaderboard</button>
                         <button class="card-type-btn active" data-type="regular">🎯 Regular</button>
                         <button class="card-type-btn completionist" data-type="completionist">🏆 Completionist</button>
                     </div>
@@ -111,7 +111,7 @@
                 </div>
             </section>
 
-            <section id="leaderboard" class="tab-section">
+            <section id="leaderboard" class="tab-section hidden">
                 <div class="glass p-6">
                     <div class="text-center mb-6">
                         <h2 class="text-3xl font-bold text-gray-800 mb-2">Challenge Leaderboard</h2>
@@ -130,7 +130,7 @@
                     <div class="text-center mt-4 space-x-2">
                         <button id="submit-score-btn" onclick="Leaderboard.saveCurrentProgress()" class="btn-primary">Submit Score</button>
                         <button onclick="Leaderboard.refresh()" class="btn-secondary">Refresh Leaderboard</button>
-                        <button onclick="document.querySelector('a[href=\'#bingo\']').click()" class="btn-secondary">Start Challenges</button>
+                        <button id="start-challenges-btn" class="btn-secondary">Start Challenges</button>
                     </div>
                 </div>
             </section>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -2,6 +2,36 @@
 
 const App = {
     currentTab: null,
+    openTab: (targetId) => {
+        const tabLinks = document.querySelectorAll('.tab-link');
+        const tabSections = document.querySelectorAll('.tab-section');
+
+        App.currentTab = targetId;
+
+        tabSections.forEach(section => {
+            section.classList.toggle('hidden', section.id !== targetId);
+        });
+
+        tabLinks.forEach(l => l.classList.remove('active'));
+        const targetLink = document.querySelector(`.tab-link[href="#${targetId}"]`);
+        if (targetLink) {
+            targetLink.classList.add('active');
+        }
+
+        const leaderboardBtn = document.getElementById('leaderboard-btn');
+        if (leaderboardBtn) {
+            if (targetId === 'leaderboard') {
+                leaderboardBtn.classList.add('active');
+            } else {
+                leaderboardBtn.classList.remove('active');
+            }
+        }
+
+        const nav = document.getElementById('nav');
+        if (nav && nav.classList.contains('open')) {
+            nav.classList.remove('open');
+        }
+    },
     // Initialize the application
     init: async () => {
         // Initialize all modules
@@ -40,11 +70,11 @@ const App = {
     // Set up event listeners
     setupEventListeners: () => {
         const tabLinks = document.querySelectorAll('.tab-link');
-        const tabSections = document.querySelectorAll('.tab-section');
         const activeLink = document.querySelector('.tab-link.active');
         if (activeLink) {
             App.currentTab = activeLink.getAttribute('href').substring(1);
         }
+
         const menuToggle = document.getElementById('menu-toggle');
         const nav = document.getElementById('nav');
 
@@ -53,21 +83,19 @@ const App = {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
                 const targetId = link.getAttribute('href').substring(1);
-                App.currentTab = targetId;
-                
-                tabSections.forEach(section => {
-                    section.classList.toggle('hidden', section.id !== targetId);
-                });
-
-                tabLinks.forEach(l => l.classList.remove('active'));
-                link.classList.add('active');
-
-                // Close mobile menu on navigation
-                if (nav.classList.contains('open')) {
-                    nav.classList.remove('open');
-                }
+                App.openTab(targetId);
             });
         });
+
+        const leaderboardBtn = document.getElementById('leaderboard-btn');
+        if (leaderboardBtn) {
+            leaderboardBtn.addEventListener('click', () => App.openTab('leaderboard'));
+        }
+
+        const startChallengesBtn = document.getElementById('start-challenges-btn');
+        if (startChallengesBtn) {
+            startChallengesBtn.addEventListener('click', () => App.openTab('bingo'));
+        }
 
         // Mobile menu toggle
         menuToggle.addEventListener('click', () => {

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -77,12 +77,13 @@ const BingoTracker = {
     },
 
     initCardSelector: () => {
-        const buttons = document.querySelectorAll('.card-type-btn');
+        const buttons = document.querySelectorAll('.card-type-btn[data-type]');
         buttons.forEach(btn => {
             btn.addEventListener('click', () => {
                 buttons.forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
                 BingoTracker.currentMode = btn.dataset.type;
+                App.openTab('bingo');
                 BingoTracker.renderGrid();
                 BingoTracker.updateStats();
             });


### PR DESCRIPTION
## Summary
- shift default active tab to "Challenge Tracker" and hide leaderboard section initially
- add a new Leaderboard button to the bingo selector
- update scripts to handle the new button via `App.openTab`
- ensure bingo selector ignores the new button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687925a332fc8331b2efad76f301a90a