### PR TITLE
Embed leaderboard into bingo tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                     </div>
 
                     <div class="card-selector">
-                        <button id="leaderboard-btn" class="card-type-btn">🏅 Leaderboard</button>
+                        <button id="leaderboard-btn" class="card-type-btn" data-type="leaderboard">🏅 Leaderboard</button>
                         <button class="card-type-btn active" data-type="regular">🎯 Regular</button>
                         <button class="card-type-btn completionist" data-type="completionist">🏆 Completionist</button>
                     </div>
@@ -75,6 +75,28 @@
                     <div class="text-center mt-6 flex justify-center space-x-4">
                         <button class="btn-primary" onclick="BingoTracker.reset()">Reset Progress</button>
                         <button class="btn-secondary" onclick="BingoTracker.shareProgress()">Share Progress 📤</button>
+                    </div>
+
+                    <div id="leaderboard" class="hidden mt-8">
+                        <div class="text-center mb-6">
+                            <h2 class="text-3xl font-bold text-gray-800 mb-2">Challenge Leaderboard</h2>
+                            <p class="text-gray-600">See who's leading the Faith Challenge!</p>
+                            <div id="backend-status" class="text-sm text-gray-500 mt-2">
+                                <span id="firebase-status">🔥 Firebase: <span class="loading">Connecting...</span></span>
+                                <span class="mx-2">|</span>
+                                <span id="nodejs-status">📡 Node.js: <span class="loading">Connecting...</span></span>
+                            </div>
+                        </div>
+                        <div class="mb-4">
+                            <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
+                            <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                        </div>
+                        <ul id="leaderboard-list" class="space-y-2"></ul>
+                        <div class="text-center mt-4 space-x-2">
+                            <button id="submit-score-btn" onclick="Leaderboard.saveCurrentProgress()" class="btn-primary">Submit Score</button>
+                            <button onclick="Leaderboard.refresh()" class="btn-secondary">Refresh Leaderboard</button>
+                            <button id="start-challenges-btn" class="btn-secondary">Start Challenges</button>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -111,29 +133,6 @@
                 </div>
             </section>
 
-            <section id="leaderboard" class="tab-section hidden">
-                <div class="glass p-6">
-                    <div class="text-center mb-6">
-                        <h2 class="text-3xl font-bold text-gray-800 mb-2">Challenge Leaderboard</h2>
-                        <p class="text-gray-600">See who's leading the Faith Challenge!</p>
-                        <div id="backend-status" class="text-sm text-gray-500 mt-2">
-                            <span id="firebase-status">🔥 Firebase: <span class="loading">Connecting...</span></span>
-                            <span class="mx-2">|</span>
-                            <span id="nodejs-status">📡 Node.js: <span class="loading">Connecting...</span></span>
-                        </div>
-                    </div>
-                    <div class="mb-4">
-                        <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
-                        <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
-                    </div>
-                    <ul id="leaderboard-list" class="space-y-2"></ul>
-                    <div class="text-center mt-4 space-x-2">
-                        <button id="submit-score-btn" onclick="Leaderboard.saveCurrentProgress()" class="btn-primary">Submit Score</button>
-                        <button onclick="Leaderboard.refresh()" class="btn-secondary">Refresh Leaderboard</button>
-                        <button id="start-challenges-btn" class="btn-secondary">Start Challenges</button>
-                    </div>
-                </div>
-            </section>
         </main>
 
         <footer class="text-center text-gray-600 text-sm py-4">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -18,13 +18,11 @@ const App = {
             targetLink.classList.add('active');
         }
 
-        const leaderboardBtn = document.getElementById('leaderboard-btn');
-        if (leaderboardBtn) {
-            if (targetId === 'leaderboard') {
-                leaderboardBtn.classList.add('active');
-            } else {
-                leaderboardBtn.classList.remove('active');
-            }
+        const leaderboardBtn = document.querySelector('.card-type-btn[data-type="leaderboard"]');
+        const leaderboardSection = document.getElementById('leaderboard');
+        if (leaderboardSection && targetId !== 'bingo') {
+            leaderboardSection.classList.add('hidden');
+            if (leaderboardBtn) leaderboardBtn.classList.remove('active');
         }
 
         const nav = document.getElementById('nav');
@@ -87,15 +85,7 @@ const App = {
             });
         });
 
-        const leaderboardBtn = document.getElementById('leaderboard-btn');
-        if (leaderboardBtn) {
-            leaderboardBtn.addEventListener('click', () => App.openTab('leaderboard'));
-        }
 
-        const startChallengesBtn = document.getElementById('start-challenges-btn');
-        if (startChallengesBtn) {
-            startChallengesBtn.addEventListener('click', () => App.openTab('bingo'));
-        }
 
         // Mobile menu toggle
         menuToggle.addEventListener('click', () => {

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -72,22 +72,63 @@ const BingoTracker = {
         BingoTracker.loadProgress();
         BingoTracker.setDailyChallenge();
         BingoTracker.initCardSelector();
+        const startBtn = document.getElementById('start-challenges-btn');
+        if (startBtn) {
+            startBtn.addEventListener('click', () => {
+                const active = document.querySelector('.card-type-btn[data-type="' + BingoTracker.currentMode + '"]');
+                document.querySelectorAll('.card-type-btn').forEach(b => b.classList.remove('active'));
+                if (active) active.classList.add('active');
+                BingoTracker.hideLeaderboard();
+            });
+        }
         BingoTracker.renderGrid();
         BingoTracker.updateStats();
     },
 
     initCardSelector: () => {
-        const buttons = document.querySelectorAll('.card-type-btn[data-type]');
+        const buttons = document.querySelectorAll('.card-type-btn');
         buttons.forEach(btn => {
             btn.addEventListener('click', () => {
                 buttons.forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
-                BingoTracker.currentMode = btn.dataset.type;
-                App.openTab('bingo');
-                BingoTracker.renderGrid();
-                BingoTracker.updateStats();
+
+                const type = btn.dataset.type;
+                if (type === 'leaderboard') {
+                    BingoTracker.showLeaderboard();
+                } else {
+                    BingoTracker.currentMode = type;
+                    BingoTracker.hideLeaderboard();
+                    App.openTab('bingo');
+                    BingoTracker.renderGrid();
+                    BingoTracker.updateStats();
+                }
             });
         });
+
+        // Ensure leaderboard hidden on init
+        BingoTracker.hideLeaderboard();
+    },
+
+    showLeaderboard: () => {
+        const section = document.getElementById('leaderboard');
+        const grid = document.getElementById('bingo-grid');
+        const stats = document.querySelector('.stats-container');
+        if (section) section.classList.remove('hidden');
+        if (grid) grid.classList.add('hidden');
+        if (stats) stats.classList.add('hidden');
+        App.openTab('bingo');
+        if (window.Leaderboard && typeof Leaderboard.loadLeaderboard === 'function') {
+            Leaderboard.loadLeaderboard();
+        }
+    },
+
+    hideLeaderboard: () => {
+        const section = document.getElementById('leaderboard');
+        const grid = document.getElementById('bingo-grid');
+        const stats = document.querySelector('.stats-container');
+        if (section) section.classList.add('hidden');
+        if (grid) grid.classList.remove('hidden');
+        if (stats) stats.classList.remove('hidden');
     },
 
     getCurrentChallenges: () => {


### PR DESCRIPTION
## Summary
- show leaderboard within bingo tab instead of switching sections
- wire up new card selector mode for leaderboard
- keep leaderboard hidden when leaving the bingo tab

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687927e121ac8331b4cac9e4827253a2