### PR TITLE
Show username field on tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
                         Total Points: <span id="total-points">0</span>
                     </div>
 
+                    <div class="mb-4" id="username-container">
+                        <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
+                        <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                    </div>
+
                     <div class="card-selector">
                         <button id="leaderboard-btn" class="card-type-btn" data-type="leaderboard">🏅 Leaderboard</button>
                         <button class="card-type-btn active" data-type="regular">🎯 Regular</button>
@@ -86,10 +91,6 @@
                                 <span class="mx-2">|</span>
                                 <span id="nodejs-status">📡 Node.js: <span class="loading">Connecting...</span></span>
                             </div>
-                        </div>
-                        <div class="mb-4">
-                            <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
-                            <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
                         </div>
                         <ul id="leaderboard-list" class="space-y-2"></ul>
                         <div class="text-center mt-4 space-x-2">


### PR DESCRIPTION
## Summary
- keep leaderboard button view but make sure new leaderboard toggle works
- always show the username field on the Challenge Tracker page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792a838318833189c07d77ec76fbd1