### PR TITLE
Show top 25 leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 
                     <div id="leaderboard" class="hidden mt-8">
                         <div class="text-center mb-6">
-                            <h2 class="text-3xl font-bold text-gray-800 mb-2">Challenge Leaderboard</h2>
+                            <h2 class="text-3xl font-bold text-gray-800 mb-2">Top 25 Challenge Leaders</h2>
                             <p class="text-gray-600">See who's leading the Faith Challenge!</p>
                             <div id="backend-status" class="text-sm text-gray-500 mt-2">
                                 <span id="firebase-status">🔥 Firebase: <span class="loading">Connecting...</span></span>
@@ -92,7 +92,7 @@
                                 <span id="nodejs-status">📡 Node.js: <span class="loading">Connecting...</span></span>
                             </div>
                         </div>
-                        <ul id="leaderboard-list" class="space-y-2"></ul>
+                        <ul id="leaderboard-list" class="space-y-1 text-sm max-w-md mx-auto"></ul>
                         <div class="text-center mt-4 space-x-2">
                             <button id="submit-score-btn" onclick="Leaderboard.saveCurrentProgress()" class="btn-primary">Submit Score</button>
                             <button onclick="Leaderboard.refresh()" class="btn-secondary">Refresh Leaderboard</button>

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -114,6 +114,7 @@ const BingoTracker = {
         if (grid) grid.classList.add('hidden');
         if (stats) stats.classList.add('hidden');
         App.openTab('bingo');
+        App.currentTab = 'leaderboard';
         if (window.Leaderboard && typeof Leaderboard.loadLeaderboard === 'function') {
             Leaderboard.loadLeaderboard();
         }
@@ -126,6 +127,7 @@ const BingoTracker = {
         if (section) section.classList.add('hidden');
         if (grid) grid.classList.remove('hidden');
         if (stats) stats.classList.remove('hidden');
+        App.currentTab = 'bingo';
     },
 
     getCurrentChallenges: () => {

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -61,7 +61,7 @@ const Leaderboard = {
                     if (App.currentTab === 'leaderboard') {
                         Leaderboard.renderLeaderboard(scores);
                     }
-                });
+                }, 25);
 
                 // Resolve the initialization promise
                 Leaderboard._resolveInitialization();
@@ -110,7 +110,7 @@ const Leaderboard = {
         if (Leaderboard.firebaseLeaderboard && Leaderboard.firebaseLeaderboard.isAvailable()) {
             Leaderboard.showLoading();
             try {
-                const scores = await Leaderboard.firebaseLeaderboard.getTopScores(50);
+                const scores = await Leaderboard.firebaseLeaderboard.getTopScores(25);
                 Leaderboard.renderLeaderboard(scores);
                 return true;
             } catch (error) {
@@ -206,7 +206,7 @@ const Leaderboard = {
         }
 
         // Sort by score descending (in case not sorted)
-        const sortedLeaderboard = [...leaderboard].sort((a, b) => b.score - a.score);
+        const sortedLeaderboard = [...leaderboard].sort((a, b) => b.score - a.score).slice(0, 25);
 
         list.innerHTML = sortedLeaderboard.map((entry, index) => {
             const medal = index === 0 ? '🥇' : index === 1 ? '🥈' : index === 2 ? '🥉' : '';
@@ -220,14 +220,14 @@ const Leaderboard = {
             const score = entry.score || 0;
             
             return `
-                <li class="flex justify-between items-center p-3 rounded-lg border ${bgClass} transition-all hover:shadow-md">
+                <li class="flex justify-between items-center p-2 rounded-lg border ${bgClass} transition-all hover:shadow-md text-sm">
                     <div class="flex items-center">
-                        <span class="w-8 text-lg">${medal || `${index + 1}.`}</span>
-                        <span class="font-medium">${username}</span>
+                        <span class="w-6">${medal || `${index + 1}.`}</span>
+                        <span class="font-medium ml-1">${username}</span>
                     </div>
                     <div class="flex items-center">
-                        <span class="font-bold text-lg">${score}</span>
-                        <span class="text-sm text-gray-500 ml-2">pts</span>
+                        <span class="font-bold">${score}</span>
+                        <span class="text-xs text-gray-500 ml-1">pts</span>
                     </div>
                 </li>
             `;


### PR DESCRIPTION
## Summary
- tweak layout for leaderboard
- load top 25 scores from Firebase
- keep leaderboard active when open

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792cbf94bc83318d4a5efd18533c5e