### PR TITLE
Remove polls section and display verse on tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
                     <ul id="nav" class="hidden fixed nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
                         <li><a href="#bingo" class="tab-link active">Challenge Tracker</a></li>
                         <li><a href="#verse" class="tab-link">Hourly Verse</a></li>
-                        <li><a href="#polls" class="tab-link">Polls & Q&A</a></li>
                         <li class="hidden md:block"><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
                     </ul>
                 </div>
@@ -44,6 +43,10 @@
                         <p class="text-gray-600">Complete challenges to grow in faith during the gathering!</p>
                     </div>
 
+                    <div class="verse-container verse-compact mb-4">
+                        <div class="verse-text"></div>
+                        <div class="verse-reference"></div>
+                    </div>
                     <div class="total-points">
                         Total Points: <span id="total-points">0</span>
                     </div>
@@ -121,18 +124,6 @@
                 </div>
             </section>
 
-            <section id="polls" class="tab-section hidden">
-                <div class="glass p-6">
-                    <div class="text-center mb-6">
-                        <h2 class="text-3xl font-bold text-gray-800 mb-2">Live Polls & Q&A</h2>
-                        <p class="text-gray-600">Connect with other youth and share your thoughts</p>
-                        <p class="text-gray-600">Polls and leaderboard powered by Firebase!</p>
-                    </div>
-                    
-                    <div id="polls-container">
-                        </div>
-                </div>
-            </section>
 
         </main>
 
@@ -148,7 +139,6 @@
     <script src="scripts/storage.js"></script>
     <script src="scripts/bingo.js"></script>
     <script src="scripts/verse.js"></script>
-    <script src="scripts/polls.js"></script>
     
     <script src="scripts/firebase-leaderboard.js"></script>
     <script src="scripts/leaderboard.js"></script>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -39,7 +39,6 @@ const App = {
         }
         BingoTracker.init();
         VerseManager.init();
-        PollManager.init(); // This is the corrected line
         Leaderboard.init();
 
         try {

--- a/scripts/verse.js
+++ b/scripts/verse.js
@@ -84,11 +84,11 @@ const VerseManager = {
     displayVerse: (verse) => {
         VerseManager.currentVerse = verse;
         
-        const verseText = document.getElementById('verse-text');
-        const verseReference = document.getElementById('verse-reference');
-        
-        if (verseText) verseText.textContent = verse.text;
-        if (verseReference) verseReference.textContent = verse.reference;
+        const verseTexts = document.querySelectorAll('.verse-text');
+        const verseReferences = document.querySelectorAll('.verse-reference');
+
+        verseTexts.forEach(el => { el.textContent = verse.text; });
+        verseReferences.forEach(el => { el.textContent = verse.reference; });
     },
 
     // Get random verse

--- a/styles/global.css
+++ b/styles/global.css
@@ -307,6 +307,18 @@ body {
     margin-top: 1rem;
 }
 
+.verse-compact {
+    padding: 1rem;
+}
+
+.verse-compact .verse-text {
+    font-size: 1rem;
+}
+
+.verse-compact .verse-reference {
+    font-size: 0.875rem;
+}
+
 .verse-container::before,
 .verse-container::after {
     content: '"';


### PR DESCRIPTION
## Summary
- remove Polls & Q&A navigation and section
- show Hourly Verse at the top of the challenge tracker page
- remove PollManager initialization
- support multiple verse containers and smaller verse style

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792d598e208331baea13b2a19ccabd