### PR TITLE
Streamline single-page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,15 +22,7 @@
                         <h1 class="text-2xl font-bold text-gray-800">ENDURE 2025</h1>
                         <p class="text-sm text-gray-600">LCMS Youth Gathering 2025</p>
                     </div>
-                    <button id="menu-toggle" class="md:hidden text-gray-800 focus:outline-none text-2xl">
-                        &#9776;
-                    </button>
-                    <button id="invite-btn-mobile" class="btn-primary md:hidden ml-2">Invite a Friend</button>
-                    <ul id="nav" class="hidden fixed nav-glass p-8 flex flex-col justify-center items-center space-y-6 text-2xl z-50 md:static md:flex md:flex-row md:space-x-2 md:space-y-0 md:p-0 md:relative md:inset-auto md:text-base md:rounded-md">
-                        <li><a href="#bingo" class="tab-link active">Challenge Tracker</a></li>
-                        <li><a href="#verse" class="tab-link">Hourly Verse</a></li>
-                        <li class="hidden md:block"><button id="invite-btn" class="btn-primary">Invite a Friend</button></li>
-                    </ul>
+                    <button id="invite-btn" class="btn-primary">Invite a Friend</button>
                 </div>
             </nav>
         </header>
@@ -38,9 +30,8 @@
         <main class="container mx-auto px-4 pb-8">
             <section id="bingo" class="tab-section">
                 <div class="glass p-6">
-                    <div class="text-center mb-6">
-                        <h2 class="text-3xl font-bold text-gray-800 mb-2">Faith Challenges</h2>
-                        <p class="text-gray-600">Complete challenges to grow in faith during the gathering!</p>
+                    <div class="text-center mb-2">
+                        <h2 class="text-3xl font-bold text-gray-800 mb-2">Gathering Challenge</h2>
                     </div>
 
                     <div class="verse-container verse-compact mb-4">
@@ -105,24 +96,6 @@
                 </div>
             </section>
 
-            <section id="verse" class="tab-section hidden">
-                <div class="glass p-6">
-                    <div class="text-center mb-6">
-                        <h2 class="text-3xl font-bold text-gray-800 mb-2">Hourly Verse</h2>
-                        <p class="text-gray-600">A new verse every hour to inspire your faith journey</p>
-                    </div>
-                    
-                    <div class="verse-container" id="verse-container">
-                        <div class="verse-text" id="verse-text">Loading...</div>
-                        <div class="verse-reference" id="verse-reference"></div>
-                    </div>
-                    
-                    <div class="text-center mt-6">
-                        <button class="btn-primary" onclick="VerseManager.refresh()">New Verse</button>
-                        <button class="btn-primary ml-2" onclick="VerseManager.favorite()">❤️ Favorite</button>
-                    </div>
-                </div>
-            </section>
 
 
         </main>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -25,10 +25,7 @@ const App = {
             if (leaderboardBtn) leaderboardBtn.classList.remove('active');
         }
 
-        const nav = document.getElementById('nav');
-        if (nav && nav.classList.contains('open')) {
-            nav.classList.remove('open');
-        }
+        // navigation menu removed
     },
     // Initialize the application
     init: async () => {
@@ -72,8 +69,6 @@ const App = {
             App.currentTab = activeLink.getAttribute('href').substring(1);
         }
 
-        const menuToggle = document.getElementById('menu-toggle');
-        const nav = document.getElementById('nav');
 
         // Tab navigation
         tabLinks.forEach(link => {
@@ -84,12 +79,7 @@ const App = {
             });
         });
 
-
-
-        // Mobile menu toggle
-        menuToggle.addEventListener('click', () => {
-            nav.classList.toggle('open');
-        });
+        // Mobile menu removed
     }
 };
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -604,42 +604,5 @@ body {
         gap: 0.5rem;
     }
 
-    /* Mobile dropdown navigation */
-    #nav {
-        position: fixed;
-        top: 4.5rem;
-        left: 50%;
-        width: 90%;
-        max-width: 320px;
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        align-items: center;
-        gap: 2rem;
-        padding: 3rem 1.5rem;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(20px);
-        -webkit-backdrop-filter: blur(20px);
-        z-index: 100;
-        transform: translate(-50%, 0) scale(0);
-        transition: transform 0.3s ease;
-        max-height: calc(100vh - 4.5rem);
-        overflow-y: auto;
-    }
-
-    #nav.open {
-        transform: translate(-50%, 0) scale(1);
-    }
-
-    #nav li a {
-        font-size: 1.5rem;
-        padding: 1rem;
-        width: 100%;
-        text-align: center;
-    }
-
-    #menu-toggle {
-        position: relative;
-        z-index: 150;
-    }
+    /* Mobile dropdown navigation removed */
 }


### PR DESCRIPTION
## Summary
- remove legacy Hourly Verse page
- drop mobile dropdown menu and references
- retitle challenge section to **Gathering Challenge**
- show hourly verse right below the new heading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792f883f6c8331bbaffd8dd3ee3905