### PR TITLE
Ensure total points span both modes

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -216,8 +216,9 @@ const BingoTracker = {
     },
 
     // Count total achievements including sub items
-    countAchievements: () => {
-        if (BingoTracker.currentMode === 'regular') {
+    // Optionally provide a mode ('regular' or 'completionist') to override
+    countAchievements: (mode = BingoTracker.currentMode) => {
+        if (mode === 'regular') {
             return BingoTracker.completedTiles.regular.size;
         }
         let total = 0;
@@ -229,6 +230,13 @@ const BingoTracker = {
             }
         });
         return total;
+    },
+
+    // Calculate total points across both modes
+    getTotalPoints: () => {
+        const regular = BingoTracker.countAchievements('regular');
+        const completionist = BingoTracker.countAchievements('completionist');
+        return regular + completionist;
     },
 
     openSublist: (index) => {
@@ -349,12 +357,13 @@ const BingoTracker = {
         const totalCount = BingoTracker.getCurrentChallenges().length;
         const progressPercent = Math.round((completedCount / totalCount) * 100);
         const achievements = BingoTracker.countAchievements();
-        
+        const totalPoints = BingoTracker.getTotalPoints();
+
         const elements = {
             'completed-count': completedCount,
             'progress-percent': progressPercent + '%',
             'achievement-count': achievements,
-            'total-points': achievements
+            'total-points': totalPoints
         };
         
         Object.entries(elements).forEach(([id, value]) => {

--- a/tests/bingo.test.js
+++ b/tests/bingo.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('getTotalPoints sums points from both modes', () => {
+  const code = fs.readFileSync(path.join(__dirname, '../scripts/bingo.js'), 'utf8');
+  const context = { console };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  const BingoTracker = vm.runInContext('BingoTracker', context);
+
+  BingoTracker.completedTiles.regular = new Set([1, 2]);
+  BingoTracker.completedTiles.completionist = new Set([0]);
+  BingoTracker.subItemProgress = { 0: { 0: true, 1: true } };
+
+  const total = BingoTracker.getTotalPoints();
+  expect(total).toBe(5); // 2 regular + (2 sub items + 1 tile)
+});


### PR DESCRIPTION
## Summary
- count achievements by mode in `bingo.js`
- report total points from regular and hard modes
- test combined total points logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793385d3c08331a12cddb364096a1d