### PR TITLE
Add API-based verse refresh

### DIFF
--- a/tests/verse.test.js
+++ b/tests/verse.test.js
@@ -1,0 +1,34 @@
+const { JSDOM } = require('jsdom');
+
+describe('VerseManager API refresh', () => {
+  let VerseManager;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><div class="verse-text"></div><div class="verse-reference"></div>`);
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.Utils = { showNotification: jest.fn() };
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        verses: [{ text: 'Test verse', book_name: 'Test', chapter: 1, verse: 1 }]
+      })
+    }));
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    delete global.window;
+    delete global.document;
+    delete global.Utils;
+    delete global.fetch;
+  });
+
+  test('refresh displays verse from API', async () => {
+    require('../scripts/verse.js');
+    VerseManager = window.VerseManager;
+    await VerseManager.refresh();
+    expect(VerseManager.currentVerse.text).toBe('Test verse');
+    expect(document.querySelector('.verse-text').textContent).toBe('Test verse');
+  });
+});


### PR DESCRIPTION
## Summary
- fetch daily verse from external Bible API
- expose `VerseManager` globally
- load fallback verse if API call fails
- test verse refresh API logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879340462c8833199c613e2903e9c8f