### PR TITLE
Fix leaderboard default view logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,8 +48,8 @@
                     </div>
 
                     <div class="card-selector">
-                        <button id="leaderboard-btn" class="card-type-btn" data-type="leaderboard">🏅 Leaderboard</button>
-                        <button class="card-type-btn active" data-type="regular">🎯 Regular</button>
+                        <button id="leaderboard-btn" class="card-type-btn active" data-type="leaderboard">🏅 Leaderboard</button>
+                        <button class="card-type-btn" data-type="regular">🎯 Regular</button>
                         <button class="card-type-btn completionist" data-type="completionist">🏆 Hard Mode</button>
                     </div>
                     <div class="stats-container">

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -113,8 +113,14 @@ const BingoTracker = {
             });
         });
 
-        // Ensure leaderboard is hidden on init
-        BingoTracker.hideLeaderboard();
+        // Handle initially active button
+        const activeBtn = document.querySelector('.card-type-btn.active');
+        if (activeBtn && activeBtn.dataset.type === 'leaderboard') {
+            BingoTracker.showLeaderboard();
+        } else {
+            if (activeBtn) BingoTracker.currentMode = activeBtn.dataset.type;
+            BingoTracker.hideLeaderboard();
+        }
     },
 
     showLeaderboard: () => {


### PR DESCRIPTION
## Summary
- make leaderboard button initially active on home screen
- respect active button when initializing card selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687939577f8c8331b74bc07ee7553e0a