### PR TITLE
Simplify leaderboard header

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,7 @@
 
                     <div id="leaderboard" class="hidden mt-8">
                         <div class="text-center mb-6">
-                            <h2 class="text-3xl font-bold text-gray-800 mb-2">Top 25 Challenge Leaders</h2>
-                            <p class="text-gray-600">See who's leading the Faith Challenge!</p>
+                            <h2 class="text-3xl font-bold text-gray-800 mb-2">Top 25 Leaders</h2>
                         </div>
                         <ul id="leaderboard-list" class="space-y-1 text-sm max-w-md mx-auto"></ul>
                         <div class="text-center mt-4 space-x-2">


### PR DESCRIPTION
## Summary
- tidy leaderboard section text: remove explanatory paragraph
- shorten the heading to "Top 25 Leaders"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68793b2293408331947c45b8c7284e83