### PR TITLE
Add username validation script

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,20 @@
                     </div>
 
                     <div class="mb-4" id="username-container">
-                        <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
-                        <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 p-3 text-lg md:p-2 md:text-base">
+                        <label for="username" class="block text-sm font-medium text-gray-700">
+                            Username (not your real name):
+                        </label>
+                        <input 
+                            type="text" 
+                            id="username" 
+                            maxlength="20"
+                            placeholder="Enter a fun, appropriate username"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 p-3 text-lg md:p-2 md:text-base"
+                        >
+                        <div id="username-feedback" class="text-sm mt-1 transition-all duration-200" style="display: none;"></div>
+                        <div class="text-xs text-gray-500 mt-1">
+                            Please use appropriate, family-friendly usernames only. Maximum 20 characters.
+                        </div>
                     </div>
 
                     <div class="card-selector">
@@ -100,6 +112,7 @@
     </div>
 
 
+    <script src="scripts/username-validator.js"></script>
     <script src="scripts/utils.js"></script>
     <script src="scripts/storage.js"></script>
     <script src="scripts/bingo.js"></script>

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -26,8 +26,12 @@ const Leaderboard = {
         const usernameInput = document.getElementById('username');
         if (usernameInput) {
             usernameInput.value = localStorage.getItem('username') || '';
+            usernameInput.addEventListener('input', Leaderboard.validateUsernameInput);
             usernameInput.addEventListener('change', () => {
-                localStorage.setItem('username', usernameInput.value);
+                const validation = Leaderboard.validateAndCleanUsername(usernameInput.value);
+                const cleanUsername = validation.cleanUsername;
+                usernameInput.value = cleanUsername;
+                localStorage.setItem('username', cleanUsername);
                 Leaderboard.saveCurrentProgress();
             });
         }
@@ -148,14 +152,17 @@ const Leaderboard = {
 
     saveCurrentProgress: async () => {
         const usernameInput = document.getElementById('username');
-        const username = usernameInput ? usernameInput.value.trim() || 'Anonymous' : 'Anonymous';
+        const username = usernameInput ? usernameInput.value.trim() : '';
+        const validation = Leaderboard.validateAndCleanUsername(username);
+        const cleanUsername = validation.cleanUsername;
+        const finalName = cleanUsername || 'Anonymous';
         const userId = Utils.getUserId();
         
         if (window.BingoTracker && BingoTracker.completedTiles) {
             const completedCount = BingoTracker.completedTiles[BingoTracker.currentMode || 'regular'].size;
             if (completedCount > 0) {
                 try {
-                    await Leaderboard.saveScore(userId, username, completedCount);
+                    await Leaderboard.saveScore(userId, finalName, completedCount);
                 } catch (error) {
                     console.error('Failed to save current progress:', error);
                 }

--- a/scripts/username-validator.js
+++ b/scripts/username-validator.js
@@ -1,0 +1,36 @@
+(function() {
+    window.Leaderboard = window.Leaderboard || {};
+
+    const allowedPattern = /^[A-Za-z0-9 _-]+$/;
+
+    window.Leaderboard.validateAndCleanUsername = function(username) {
+        const trimmed = (username || '').trim().slice(0, 20);
+        const clean = trimmed.replace(/[^A-Za-z0-9 _-]/g, '').slice(0, 20);
+        const isValid = clean.length > 0 && allowedPattern.test(trimmed) && trimmed.length <= 20;
+        let message = '';
+        if (!isValid) {
+            message = 'Only letters, numbers, spaces, hyphens and underscores allowed. 20 character max.';
+        }
+        return { isValid, cleanUsername: clean, message };
+    };
+
+    window.Leaderboard.validateUsernameInput = function(evt) {
+        const input = evt.target || document.getElementById('username');
+        const feedback = document.getElementById('username-feedback');
+        const { isValid, cleanUsername, message } = window.Leaderboard.validateAndCleanUsername(input.value);
+        if (!isValid) {
+            input.classList.add('border-red-500');
+            if (feedback) {
+                feedback.textContent = message;
+                feedback.style.display = 'block';
+            }
+        } else {
+            input.classList.remove('border-red-500');
+            if (feedback) {
+                feedback.textContent = '';
+                feedback.style.display = 'none';
+            }
+        }
+        return { isValid, cleanUsername, message };
+    };
+})();


### PR DESCRIPTION
## Summary
- enhance username input with placeholder, maxlength and validation feedback
- add new username validator script and hook up to leaderboard
- sanitize username before saving leaderboard entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793f59c0c48331956936247e98104b