### PR TITLE
Add username warning UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
                     <div class="mb-4" id="username-container">
                         <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
                         <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 p-3 text-lg md:p-2 md:text-base">
+                        <div id="username-feedback" class="text-sm mt-1"></div>
                     </div>
 
                     <div class="card-selector">
@@ -102,6 +103,7 @@
 
     <script src="scripts/utils.js"></script>
     <script src="scripts/username-validator.js"></script>
+    <script src="scripts/username-feedback.js"></script>
     <script src="scripts/storage.js"></script>
     <script src="scripts/bingo.js"></script>
     <script src="scripts/verse.js"></script>

--- a/scripts/username-feedback.js
+++ b/scripts/username-feedback.js
@@ -1,0 +1,39 @@
+const UsernameFeedback = {
+    init: () => {
+        const input = document.getElementById('username');
+        if (!input || !window.UsernameValidator) return;
+
+        let feedback = document.getElementById('username-feedback');
+        if (!feedback) {
+            feedback = document.createElement('div');
+            feedback.id = 'username-feedback';
+            input.insertAdjacentElement('afterend', feedback);
+        }
+        feedback.classList.add('hide');
+
+        const applyResult = () => {
+            const result = window.UsernameValidator.validateWithFeedback(input.value);
+            feedback.textContent = result.message;
+            feedback.classList.remove('success', 'error', 'warning', 'hide');
+            input.classList.remove('valid', 'invalid');
+            if (result.isValid) {
+                feedback.classList.add('show', 'success');
+                input.classList.add('valid');
+            } else {
+                const blocked = result.message === 'Please choose a more appropriate username';
+                feedback.classList.add('show', blocked ? 'warning' : 'error');
+                input.classList.add('invalid');
+            }
+        };
+
+        const handler = (event) => applyResult();
+
+        const debounced = window.Utils && Utils.debounce ? Utils.debounce(handler, 300) : handler;
+        input.addEventListener('input', debounced);
+        input.addEventListener('blur', applyResult);
+
+        applyResult();
+    }
+};
+
+document.addEventListener('DOMContentLoaded', UsernameFeedback.init);

--- a/tests/username-feedback.test.js
+++ b/tests/username-feedback.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+test('displays warning when username is blocked', () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="username-container"><input id="username"></div>');
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    console,
+    Utils: { debounce: fn => fn },
+    UsernameValidator: {
+      validateWithFeedback: jest.fn(() => ({
+        isValid: false,
+        cleanUsername: 'Clean',
+        message: 'Please choose a more appropriate username'
+      }))
+    }
+  };
+  context.window.Utils = context.Utils;
+  context.window.UsernameValidator = context.UsernameValidator;
+
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, '../scripts/username-feedback.js'), 'utf8');
+  vm.runInContext(code, context);
+
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  const input = dom.window.document.getElementById('username');
+  input.value = 'bad';
+  input.dispatchEvent(new dom.window.Event('input'));
+
+  const feedback = dom.window.document.getElementById('username-feedback');
+  expect(feedback.textContent).toBe('Please choose a more appropriate username');
+  expect(feedback.classList.contains('warning')).toBe(true);
+  expect(input.classList.contains('invalid')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- display username validation feedback
- create new `username-feedback.js` helper
- test the warning UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879725d563c83318f0bf625b51d9379