### PR TITLE
Add username display toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,10 @@
                     <div class="mb-4" id="username-container">
                         <label for="username" class="block text-sm font-medium text-gray-700">Username (not your real name):</label>
                         <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 p-3 text-lg md:p-2 md:text-base">
+                        <div id="username-display" class="hidden mt-1 flex items-center">
+                            <span id="current-username" class="font-semibold"></span>
+                            <button id="change-username-btn" class="ml-2 text-blue-600 underline text-sm">Change</button>
+                        </div>
                     </div>
 
                     <div class="card-selector">

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -24,11 +24,36 @@ const Leaderboard = {
         }
 
         const usernameInput = document.getElementById('username');
+        const usernameDisplay = document.getElementById('username-display');
+        const currentUsername = document.getElementById('current-username');
+        const changeUsernameBtn = document.getElementById('change-username-btn');
+
         if (usernameInput) {
-            usernameInput.value = localStorage.getItem('username') || '';
+            const saved = localStorage.getItem('username') || '';
+            usernameInput.value = saved;
+            if (saved && usernameDisplay && currentUsername) {
+                currentUsername.textContent = saved;
+                usernameInput.classList.add('hidden');
+                usernameDisplay.classList.remove('hidden');
+            }
+
             usernameInput.addEventListener('change', () => {
-                localStorage.setItem('username', usernameInput.value);
+                const name = usernameInput.value.trim();
+                localStorage.setItem('username', name);
+                if (usernameDisplay && currentUsername) {
+                    currentUsername.textContent = name || '';
+                    usernameInput.classList.add('hidden');
+                    usernameDisplay.classList.remove('hidden');
+                }
                 Leaderboard.saveCurrentProgress();
+            });
+        }
+
+        if (changeUsernameBtn && usernameInput && usernameDisplay) {
+            changeUsernameBtn.addEventListener('click', () => {
+                usernameDisplay.classList.add('hidden');
+                usernameInput.classList.remove('hidden');
+                usernameInput.focus();
             });
         }
 


### PR DESCRIPTION
## Summary
- show username display after entry
- hide username input once saved
- allow changing username via a button

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687973c2b2f4833196ead806cac6296b