### PR TITLE
Tighten verse and header spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div id="app-container">
         <header class="sticky top-0 mb-4 z-50">
             <nav class="nav-glass shadow-lg">
-                <div class="container relative mx-auto px-4 py-4 flex justify-between items-center">
+                <div class="container relative mx-auto px-4 py-2 flex justify-between items-center">
                     <div>
                         <h1 class="text-2xl font-bold brand-title">ENDURE</h1>
                         <p class="text-sm brand-title">LCMS Youth Gathering</p>
@@ -29,7 +29,7 @@
 
         <main class="container mx-auto px-4 pb-8">
             <section id="bingo" class="tab-section">
-                <div class="glass p-6">
+                <div class="glass p-4">
                     <div class="text-center mb-2">
                         <h2 class="text-3xl font-bold text-gray-800 mb-2">Gathering Challenge</h2>
                     </div>

--- a/styles/global.css
+++ b/styles/global.css
@@ -303,7 +303,7 @@ body {
 
 .verse-container {
     text-align: center;
-    padding: 2rem;
+    padding: 1rem;
     position: relative;
 }
 
@@ -312,18 +312,18 @@ body {
     line-height: 1.8;
     color: #1f2937;
     font-style: italic;
-    margin: 1rem 0;
+    margin: 0.5rem 0;
 }
 
 .verse-reference {
     font-size: 1rem;
     color: var(--primary-purple);
     font-weight: 600;
-    margin-top: 1rem;
+    margin-top: 0.5rem;
 }
 
 .verse-compact {
-    padding: 1rem;
+    padding: 0.5rem;
 }
 
 .verse-compact .verse-text {
@@ -612,7 +612,7 @@ body {
     }
 
     .verse-container {
-        padding: 1rem;
+        padding: 0.5rem;
     }
 
 .stats-container {


### PR DESCRIPTION
## Summary
- reduce header and content padding in index
- lower verse container padding for a more compact layout

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687974871fcc8331b15d406f9e17b00d