### PR TITLE
Add username remembering

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
                         <input type="text" id="username" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 p-3 text-lg md:p-2 md:text-base">
                         <div id="username-feedback" class="text-sm mt-1"></div>
                     </div>
+                    <div class="mb-4 hidden" id="username-display">
+                        Competing as: <span id="current-username" class="font-semibold"></span>
+                        <button id="change-username-btn" class="btn-secondary btn-compact ml-2">Change</button>
+                    </div>
 
                     <div class="card-selector">
                         <button id="leaderboard-btn" class="card-type-btn active" data-type="leaderboard">🏅 Leaderboard</button>

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -24,10 +24,37 @@ const Leaderboard = {
         }
 
         const usernameInput = document.getElementById('username');
+        const usernameContainer = document.getElementById('username-container');
+        const usernameDisplay = document.getElementById('username-display');
+        const currentUsername = document.getElementById('current-username');
+        const changeUsernameBtn = document.getElementById('change-username-btn');
+
+        const showDisplay = (name) => {
+            if (currentUsername) currentUsername.textContent = name;
+            if (usernameDisplay) usernameDisplay.classList.remove('hidden');
+            if (usernameContainer) usernameContainer.classList.add('hidden');
+        };
+
+        const showInput = () => {
+            if (usernameDisplay) usernameDisplay.classList.add('hidden');
+            if (usernameContainer) usernameContainer.classList.remove('hidden');
+        };
+
+        if (changeUsernameBtn) {
+            changeUsernameBtn.addEventListener('click', () => {
+                showInput();
+                if (usernameInput) usernameInput.focus();
+            });
+        }
+
         if (usernameInput) {
             usernameInput.value = localStorage.getItem('username') || '';
+            if (usernameInput.value) {
+                showDisplay(usernameInput.value);
+            }
             usernameInput.addEventListener('change', () => {
                 localStorage.setItem('username', usernameInput.value);
+                showDisplay(usernameInput.value);
                 Leaderboard.saveCurrentProgress();
             });
         }

--- a/styles/global.css
+++ b/styles/global.css
@@ -636,6 +636,12 @@ body {
     position: relative;
 }
 
+#username-display {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 /* Username input styling based on validation state */
 #username {
     transition: border-color 0.3s ease, box-shadow 0.3s ease;


### PR DESCRIPTION
## Summary
- remember username in local storage
- display saved username instead of the input field
- allow changing the username again

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687974b173f883318bf956b75872d27c