### PR TITLE
Improve username content filter

### DIFF
--- a/admin/username-validation.html
+++ b/admin/username-validation.html
@@ -430,7 +430,9 @@
         function loadBlockedWords() {
             const container = document.getElementById('blocked-words-list');
             const blockedWords = [
-                'damn', 'hell', 'crap', 'stupid', 'idiot', 'hate', 'kill', 'sex', 'porn', 'drug'
+                'damn', 'hell', 'crap', 'stupid', 'idiot', 'hate', 'kill', 'sex', 'porn', 'drug',
+                // Toilet talk / body function references
+                'poop', 'poo', 'pee', 'peepee', 'poopoo', 'fart', 'butt', 'toilet'
             ];
 
             container.innerHTML = blockedWords.map(word => `

--- a/scripts/username-validator.js
+++ b/scripts/username-validator.js
@@ -5,6 +5,8 @@ const UsernameValidator = {
     blockedWords: [
         // Profanity (basic examples - you'd want a more comprehensive list)
         'damn', 'hell', 'crap', 'stupid', 'idiot', 'moron', 'dumb',
+        // Toilet talk / body function references
+        'poop', 'poo', 'pee', 'peepee', 'poopoo', 'fart', 'butt', 'toilet',
         // Inappropriate references
         'sex', 'porn', 'nude', 'naked', 'drug', 'weed', 'cocaine',
         // Hate speech indicators

--- a/tests/username-validation.test.js
+++ b/tests/username-validation.test.js
@@ -2,6 +2,7 @@ const Validator = require('../scripts/username-validator');
 
 test('detects inappropriate usernames', () => {
   expect(Validator.isInappropriate('damn')).toBe(true);
+  expect(Validator.isInappropriate('poop')).toBe(true);
   expect(Validator.isInappropriate('Alice')).toBe(false);
 });
 


### PR DESCRIPTION
## Summary
- expand blocked words to catch 'toilet talk'
- update the admin dashboard list accordingly
- ensure new words are detected in tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797715fc6c833189f847c13a16ebaa