### PR TITLE
Add anti-cheat system

### DIFF
--- a/admin/anticheat-monitoring.html
+++ b/admin/anticheat-monitoring.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Anti-Cheat Monitoring</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link href="../styles/global.css" rel="stylesheet">
+    <link href="../styles/anticheat-styles.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50">
+    <div class="admin-container max-w-4xl mx-auto p-6">
+        <h1 class="text-3xl font-bold mb-4">Anti-Cheat Monitoring</h1>
+        <div class="bg-white shadow rounded-lg p-4">
+            <h2 class="text-xl font-semibold mb-2">Flagged Users</h2>
+            <div id="flagged-users">Loading...</div>
+        </div>
+    </div>
+    <script src="../scripts/anti-cheat-system.js"></script>
+    <script>
+        function renderFlagged() {
+            const container = document.getElementById('flagged-users');
+            const list = Array.from(AntiCheatSystem.flaggedUsers);
+            if (list.length === 0) {
+                container.innerHTML = '<p class="text-green-700">No flagged users.</p>';
+                return;
+            }
+            container.innerHTML = '<ul class="list-disc pl-5">' +
+                list.map(u => '<li>' + u + '</li>').join('') +
+                '</ul>';
+        }
+        document.addEventListener('DOMContentLoaded', renderFlagged);
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="styles/global.css" rel="stylesheet">
+    <link href="styles/anticheat-styles.css" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -109,7 +110,9 @@
     <script src="scripts/username-validator.js"></script>
     <script src="scripts/username-feedback.js"></script>
     <script src="scripts/storage.js"></script>
+    <script src="scripts/anti-cheat-system.js"></script>
     <script src="scripts/bingo.js"></script>
+    <script src="scripts/bingo-anticheat-integration.js"></script>
     <script src="scripts/verse.js"></script>
     
     <script src="scripts/firebase-leaderboard.js"></script>

--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -1,0 +1,63 @@
+/* Anti-Cheat monitoring system */
+
+const AntiCheatSystem = {
+    events: [],
+    flaggedUsers: new Set(),
+    lastActions: {},
+
+    recordTileCompletion(userId, tileIndex) {
+        const now = Date.now();
+        if (!this.lastActions[userId]) {
+            this.lastActions[userId] = [];
+        }
+        this.lastActions[userId].push(now);
+        const timeframe = 30000; // 30 seconds window
+        this.lastActions[userId] = this.lastActions[userId].filter(t => now - t < timeframe);
+        if (this.lastActions[userId].length > 15) {
+            this.flagUser(userId, 'Excessive rapid completions');
+        }
+
+        this.logEvent({
+            type: 'tile_complete',
+            userId,
+            tileIndex,
+            timestamp: now
+        });
+    },
+
+    logEvent(event) {
+        this.events.push(event);
+        if (this.events.length > 1000) {
+            this.events.shift();
+        }
+
+        if (typeof window !== 'undefined' && window.ValidationAnalytics &&
+            typeof window.ValidationAnalytics.trackAntiCheat === 'function') {
+            window.ValidationAnalytics.trackAntiCheat(event);
+        }
+    },
+
+    flagUser(userId, reason) {
+        if (!this.flaggedUsers.has(userId)) {
+            this.flaggedUsers.add(userId);
+            this.logEvent({
+                type: 'flag',
+                userId,
+                reason,
+                timestamp: Date.now()
+            });
+        }
+    },
+
+    isFlagged(userId) {
+        return this.flaggedUsers.has(userId);
+    }
+};
+
+if (typeof window !== 'undefined') {
+    window.AntiCheatSystem = AntiCheatSystem;
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = AntiCheatSystem;
+}

--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -1,0 +1,16 @@
+/* Integration between BingoTracker and AntiCheatSystem */
+(function() {
+    if (typeof window === 'undefined') return;
+    const tracker = window.BingoTracker;
+    const ac = window.AntiCheatSystem;
+    if (!tracker || !ac) return;
+
+    const originalToggle = tracker.toggleTile;
+    tracker.toggleTile = function(index) {
+        const userId = window.Utils && typeof Utils.getUserId === 'function'
+            ? Utils.getUserId()
+            : 'anonymous';
+        ac.recordTileCompletion(userId, index);
+        return originalToggle.call(tracker, index);
+    };
+})();

--- a/scripts/validation-analytics.js
+++ b/scripts/validation-analytics.js
@@ -1,5 +1,3 @@
-// Username Validation Analytics System
-// This module tracks and analyzes username validation patterns
 
 class ValidationAnalytics {
     constructor() {
@@ -56,6 +54,19 @@ class ValidationAnalytics {
         if (this.events.length > 10000) {
             this.events = this.events.slice(-5000);
         }
+    trackAntiCheat(event) {
+        const acEvent = {
+            timestamp: new Date().toISOString(),
+            ...event
+        };
+        this.antiCheatEvents.push(acEvent);
+        if (this.antiCheatEvents.length > 1000) {
+            this.antiCheatEvents = this.antiCheatEvents.slice(-500);
+        }
+    }
+
+
+
     }
 
     // Update statistics based on validation event
@@ -135,6 +146,7 @@ class ValidationAnalytics {
             violations: this.getViolationAnalysis(),
             patterns: this.getPatternAnalysis(),
             performance: this.getPerformanceAnalysis(),
+            antiCheat: this.antiCheatEvents.slice(-100),
             recommendations: this.getRecommendations()
         };
 
@@ -507,8 +519,11 @@ class ValidationAnalytics {
                 
                 this.events = data.events || [];
                 this.patterns = new Map(data.patterns || []);
+                this.antiCheatEvents = data.antiCheatEvents || [];
+
                 
                 if (data.cleaningStats) {
+
                     this.cleaningStats = {
                         ...data.cleaningStats,
                         commonViolations: new Map(data.cleaningStats.commonViolations || [])
@@ -534,6 +549,7 @@ class ValidationAnalytics {
             timestamp: new Date().toISOString(),
             report: report,
             rawEvents: this.events,
+            antiCheatEvents: this.antiCheatEvents,
             version: '1.0.0'
         };
 

--- a/styles/anticheat-styles.css
+++ b/styles/anticheat-styles.css
@@ -1,0 +1,32 @@
+.locked-challenge {
+    position: relative;
+    pointer-events: none;
+    filter: grayscale(0.8);
+}
+
+.locked-challenge::after {
+    content: 'Locked';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    font-weight: bold;
+    font-size: 1.25rem;
+}
+
+.timed-challenge.pending {
+    opacity: 0.6;
+}
+
+.timed-challenge.unlocked {
+    animation: anticheat-pulse 1s ease-in-out infinite;
+}
+
+@keyframes anticheat-pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}


### PR DESCRIPTION
## Summary
- add AntiCheatSystem with BingoTracker integration
- style rules for locked/timed challenges
- add admin monitoring page for flagged users
- extend ValidationAnalytics to record anti-cheat events
- load new scripts and styles in index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797a8aaf8c8331b731a58279925ec5