### PR TITLE
Implement challenge completion intervals

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -4,8 +4,35 @@ const AntiCheatSystem = {
     events: [],
     flaggedUsers: new Set(),
     lastActions: {},
+    minimumIntervals: new Map(),
+    userCompletionTimes: new Map(),
 
-    recordTileCompletion(userId, tileIndex) {
+    setupChallengeRules() {
+        this.minimumIntervals.clear();
+        // Regular challenges (in minutes)
+        this.minimumIntervals.set('regular', new Map([
+            [0, 15],   // Selfie at entrance - 15 min
+            [1, 30],   // Learn someone's name - 30 min
+            // ... customize as needed
+        ]));
+
+        // Completionist challenges (in hours)
+        this.minimumIntervals.set('completionist', new Map([
+            [0, 24],   // Meet all 50 states - 24 hours
+            [1, 12],   // Meet 5 countries - 12 hours
+            // ... customize as needed
+        ]));
+    },
+
+    getMinimumInterval(mode, index) {
+        const m = this.minimumIntervals.get(mode);
+        if (!m) return 0;
+        const val = m.get(index);
+        if (!val) return 0;
+        return mode === 'regular' ? val * 60 * 1000 : val * 60 * 60 * 1000;
+    },
+
+    recordTileCompletion(userId, tileIndex, mode = 'regular') {
         const now = Date.now();
         if (!this.lastActions[userId]) {
             this.lastActions[userId] = [];
@@ -15,6 +42,20 @@ const AntiCheatSystem = {
         this.lastActions[userId] = this.lastActions[userId].filter(t => now - t < timeframe);
         if (this.lastActions[userId].length > 15) {
             this.flagUser(userId, 'Excessive rapid completions');
+        }
+
+        const allowed = this.getMinimumInterval(mode, tileIndex);
+        if (allowed > 0) {
+            let userMap = this.userCompletionTimes.get(userId);
+            if (!userMap) {
+                userMap = new Map();
+                this.userCompletionTimes.set(userId, userMap);
+            }
+            const last = userMap.get(`${mode}:${tileIndex}`) || 0;
+            if (now - last < allowed) {
+                this.flagUser(userId, 'Completed challenge too quickly');
+            }
+            userMap.set(`${mode}:${tileIndex}`, now);
         }
 
         this.logEvent({
@@ -53,6 +94,8 @@ const AntiCheatSystem = {
         return this.flaggedUsers.has(userId);
     }
 };
+
+AntiCheatSystem.setupChallengeRules();
 
 if (typeof window !== 'undefined') {
     window.AntiCheatSystem = AntiCheatSystem;

--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -10,7 +10,7 @@
         const userId = window.Utils && typeof Utils.getUserId === 'function'
             ? Utils.getUserId()
             : 'anonymous';
-        ac.recordTileCompletion(userId, index);
+        ac.recordTileCompletion(userId, index, tracker.currentMode || 'regular');
         return originalToggle.call(tracker, index);
     };
 })();


### PR DESCRIPTION
## Summary
- add challenge interval rules to anti-cheat system
- enforce challenge cooldown using setupChallengeRules
- pass current mode to anti-cheat integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797d84ef148331bd2e6601a0f0826e