### PR TITLE
Improve username block message

### DIFF
--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -52,9 +52,21 @@ const Leaderboard = {
             if (usernameInput.value) {
                 showDisplay(usernameInput.value);
             }
+
             usernameInput.addEventListener('change', () => {
-                localStorage.setItem('username', usernameInput.value);
-                showDisplay(usernameInput.value);
+                let name = usernameInput.value.trim();
+                if (window.UsernameValidator &&
+                    typeof window.UsernameValidator.getCleanUsername === 'function') {
+                    const clean = window.UsernameValidator.getCleanUsername(name);
+                    if (clean !== name && window.Utils?.showNotification) {
+                        Utils.showNotification(`Username changed to "${clean}" due to policy.`, 'warning');
+                    }
+                    name = clean;
+                }
+
+                usernameInput.value = name;
+                localStorage.setItem('username', name);
+                showDisplay(name);
                 Leaderboard.saveCurrentProgress();
             });
         }

--- a/scripts/username-feedback.js
+++ b/scripts/username-feedback.js
@@ -14,6 +14,9 @@ const UsernameFeedback = {
         const applyResult = () => {
             const result = window.UsernameValidator.validateWithFeedback(input.value);
             feedback.textContent = result.message;
+            if (!result.isValid && result.cleanUsername && result.cleanUsername !== input.value.trim()) {
+                feedback.textContent += ` Using: "${result.cleanUsername}"`;
+            }
             feedback.classList.remove('success', 'error', 'warning', 'hide');
             input.classList.remove('valid', 'invalid');
             if (result.isValid) {

--- a/tests/username-feedback.test.js
+++ b/tests/username-feedback.test.js
@@ -31,7 +31,7 @@ test('displays warning when username is blocked', () => {
   input.dispatchEvent(new dom.window.Event('input'));
 
   const feedback = dom.window.document.getElementById('username-feedback');
-  expect(feedback.textContent).toBe('Please choose a more appropriate username');
+  expect(feedback.textContent).toBe('Please choose a more appropriate username Using: "Clean"');
   expect(feedback.classList.contains('warning')).toBe(true);
   expect(input.classList.contains('invalid')).toBe(true);
 });


### PR DESCRIPTION
## Summary
- show forced username if invalid username is cleaned
- warn users that username was changed automatically
- document changed feedback in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687983adf14c8331ac74d77c735be83f