### PR TITLE
Adjust event start date

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -10,7 +10,7 @@ const AntiCheatSystem = {
     
     // NEW: Event date configuration
     eventConfig: {
-        startDate: new Date('2025-07-19T00:00:00'), // July 19, 2025
+        startDate: new Date('2025-07-17T00:00:00'), // July 17, 2025
         endDate: new Date('2025-07-25T23:59:59'),   // July 25, 2025
         isEventActive: function() {
             const now = new Date();

--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -29,7 +29,7 @@
                 if (validation.type === 'temporal_lock') {
                     const eventStatus = ac.getEventStatus();
                     if (eventStatus.dayOfEvent < 1) {
-                        message = `Challenges unlock on July 19th, 2025! Check back during the Youth Gathering.`;
+                        message = `Challenges unlock on July 17th, 2025! Check back during the Youth Gathering.`;
                     } else if (mode === 'completionist') {
                         message = `This Hard Mode challenge unlocks later in the event. Keep checking back!`;
                     }
@@ -168,7 +168,7 @@
                 const daysUntil = Math.ceil((ac.eventConfig.startDate - new Date()) / (1000 * 60 * 60 * 24));
                 statusContainer.innerHTML = `
                     <div class="text-center text-blue-600">
-                        ⏰ Challenges unlock in ${daysUntil} days (July 19th)
+                        ⏰ Challenges unlock in ${daysUntil} days (July 17th)
                     </div>
                 `;
             } else {


### PR DESCRIPTION
## Summary
- start events on July 17 instead of July 19
- update user-facing messages for new start date

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879865ad7888331beef8dfeae145377