### PR TITLE
Fix BingoTracker global assignment

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -495,3 +495,12 @@ const BingoTracker = {
         }
     }
 };
+
+// Export for use in other modules and make available globally
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = BingoTracker;
+}
+
+if (typeof window !== 'undefined') {
+    window.BingoTracker = BingoTracker;
+}


### PR DESCRIPTION
## Summary
- make `BingoTracker` available on `window` and via module exports so integrations can access it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798a3abc9483318e8044d3a8a87439