### PR TITLE
Release challenges based on event days

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -83,24 +83,36 @@ const AntiCheatSystem = {
     // NEW: Check if challenge should be available based on event day
     isChallengeAvailable(mode, index) {
         const dayOfEvent = this.eventConfig.getDayOfEvent();
-        
+
         // Before event starts - no challenges available
         if (dayOfEvent < 1) return false;
-        
+
         // After event ends - all challenges available for completion
         if (dayOfEvent > 7) return true;
-        
+
         if (mode === 'regular') {
             // Regular challenges unlock progressively
-            // Days 1-2: All challenges available
-            // This is more permissive than strict day-by-day unlocking
             return dayOfEvent >= 1;
         } else if (mode === 'completionist') {
-            // Completionist challenges have stricter unlocking
-            const unlockDay = Math.floor(index / 3) + 1; // Every 3 challenges unlock per day
+            // Custom unlock schedule for certain challenges
+            if (index === 3) {
+                // Convention center games start Saturday (Day 3)
+                return dayOfEvent >= 3;
+            }
+            if (index === 4 || index === 14) {
+                // Sessions/workshops and exhibitor booths open Sunday (Day 4)
+                return dayOfEvent >= 4;
+            }
+            if (index === 11) {
+                // Daily acts of kindness available from the start
+                return dayOfEvent >= 1;
+            }
+
+            // Default: unlock groups of three each day
+            const unlockDay = Math.floor(index / 3) + 1;
             return dayOfEvent >= unlockDay;
         }
-        
+
         return true;
     },
 

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -271,14 +271,20 @@ const BingoTracker = {
 
         const overlay = document.createElement('div');
         overlay.className = 'sublist-overlay';
-        const listItems = challenge.sublist.map((item,i)=>{
+        const dayOfEvent = window.AntiCheatSystem ?
+            window.AntiCheatSystem.eventConfig.getDayOfEvent() : 8;
+
+        const listItems = challenge.sublist.map((item, i) => {
+            const unlocked = index !== 11 || dayOfEvent > i;
             if (challenge.freeText) {
                 const val = progress[i] || '';
                 const selected = val ? 'selected' : '';
-                return `<li><input class="sub-item-input ${selected}" data-sub="${i}" placeholder="${item}" value="${val}"></li>`;
+                const disabled = unlocked ? '' : 'disabled';
+                return `<li><input class="sub-item-input ${selected}" data-sub="${i}" placeholder="${item}" value="${val}" ${disabled}></li>`;
             }
             const selected = progress.has(i) ? 'selected' : '';
-            return `<li><button class="sub-item-btn ${selected}" data-sub="${i}">${item}</button></li>`;
+            const disabled = unlocked ? '' : 'disabled';
+            return `<li><button class="sub-item-btn ${selected}" data-sub="${i}" ${disabled}>${item}</button></li>`;
         }).join('');
         overlay.innerHTML = `
             <div class="sublist-content relative">
@@ -292,6 +298,12 @@ const BingoTracker = {
         const handleClick = (e) => {
             if (e.target.matches('.sub-item-btn')) {
                 const sub = parseInt(e.target.dataset.sub,10);
+                if (index === 11 && dayOfEvent <= sub) {
+                    if (window.Utils && Utils.showNotification) {
+                        Utils.showNotification(`Come back on Day ${sub+1} to complete this act!`, 'warning');
+                    }
+                    return;
+                }
                 if (progress.has(sub)) {
                     progress.delete(sub);
                     e.target.classList.remove('selected');
@@ -315,6 +327,13 @@ const BingoTracker = {
         const handleInput = (e) => {
             if (e.target.matches('.sub-item-input')) {
                 const sub = parseInt(e.target.dataset.sub,10);
+                if (index === 11 && dayOfEvent <= sub) {
+                    if (window.Utils && Utils.showNotification) {
+                        Utils.showNotification(`Come back on Day ${sub+1} to complete this act!`, 'warning');
+                    }
+                    e.target.value = progress[sub] || '';
+                    return;
+                }
                 const trimmed = e.target.value.trim();
                 if (trimmed === '') {
                     delete progress[sub];

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -1,0 +1,30 @@
+const AntiCheat = require('../scripts/anti-cheat-system');
+
+describe('challenge availability schedule', () => {
+  const originalGetDay = AntiCheat.eventConfig.getDayOfEvent;
+
+  afterEach(() => {
+    AntiCheat.eventConfig.getDayOfEvent = originalGetDay;
+  });
+
+  test('convention center games unlock on day 3', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 2;
+    expect(AntiCheat.isChallengeAvailable('completionist', 3)).toBe(false);
+    AntiCheat.eventConfig.getDayOfEvent = () => 3;
+    expect(AntiCheat.isChallengeAvailable('completionist', 3)).toBe(true);
+  });
+
+  test('sessions and booths unlock on day 4', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 3;
+    expect(AntiCheat.isChallengeAvailable('completionist', 4)).toBe(false);
+    expect(AntiCheat.isChallengeAvailable('completionist', 14)).toBe(false);
+    AntiCheat.eventConfig.getDayOfEvent = () => 4;
+    expect(AntiCheat.isChallengeAvailable('completionist', 4)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 14)).toBe(true);
+  });
+
+  test('daily acts of kindness available from start', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- customize challenge unlocking by day
- drip release kindness sub-items each day
- add test for new availability rules

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879959a38c88331b354086c10e1fe2c