### PR TITLE
Improve anti-cheat cooldown display

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -7,6 +7,7 @@ const AntiCheatSystem = {
     lastActions: {},
     minimumIntervals: new Map(),
     userCompletionTimes: new Map(),
+    cooldownScale: 0.5,
     
     // NEW: Event date configuration
     eventConfig: {
@@ -162,11 +163,14 @@ const AntiCheatSystem = {
             
             if (timeSinceLastCompletion < minInterval) {
                 const remainingTime = minInterval - timeSinceLastCompletion;
-                const remainingMinutes = Math.ceil(remainingTime / (1000 * 60));
-                
+                let readable = `${Math.ceil(remainingTime / (1000 * 60))} minutes`;
+                if (typeof window !== 'undefined' && window.Utils && typeof window.Utils.formatDuration === 'function') {
+                    readable = window.Utils.formatDuration(remainingTime);
+                }
+
                 return {
                     allowed: false,
-                    reason: `Please wait ${remainingMinutes} more minutes before completing this challenge again`,
+                    reason: `Please wait ${readable} before completing this challenge again`,
                     type: 'cooldown',
                     remainingTime: remainingTime
                 };
@@ -181,7 +185,9 @@ const AntiCheatSystem = {
         if (!m) return 0;
         const val = m.get(index);
         if (!val) return 0;
-        return mode === 'regular' ? val * 60 * 1000 : val * 60 * 60 * 1000;
+        const base = mode === 'regular' ? val * 60 * 1000 : val * 60 * 60 * 1000;
+        const scale = this.cooldownScale || 1;
+        return base * scale;
     },
 
     // UPDATED: Record completion with enhanced validation

--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -34,8 +34,11 @@
                         message = `This Hard Mode challenge unlocks later in the event. Keep checking back!`;
                     }
                 } else if (validation.type === 'cooldown') {
-                    const remainingMinutes = Math.ceil(validation.remainingTime / (1000 * 60));
-                    message = `Please wait ${remainingMinutes} more minutes before completing this challenge.`;
+                    let friendly = `${Math.ceil(validation.remainingTime / (1000 * 60))} minutes`;
+                    if (window.Utils && typeof Utils.formatDuration === 'function') {
+                        friendly = Utils.formatDuration(validation.remainingTime);
+                    }
+                    message = `Please wait ${friendly} before completing this challenge.`;
                 } else if (validation.type === 'rate_limit') {
                     message = `Slow down there, speed racer! 🏃‍♂️ Take time to truly experience each challenge.`;
                 }
@@ -102,8 +105,13 @@
         }
         
         const updateTimer = () => {
-            const minutes = Math.ceil(remainingTime / (1000 * 60));
-            timer.textContent = `${minutes}m`;
+            let label;
+            if (window.Utils && typeof Utils.formatDurationShort === 'function') {
+                label = Utils.formatDurationShort(remainingTime);
+            } else {
+                label = `${Math.ceil(remainingTime / (1000 * 60))}m`;
+            }
+            timer.textContent = label;
             timer.style.display = 'block';
             
             remainingTime -= 1000;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -23,6 +23,30 @@ const Utils = {
         return Math.floor(diff / (1000 * 60 * 60 * 24));
     },
 
+    // Convert milliseconds to a readable duration
+    formatDuration: (ms) => {
+        const minutes = Math.ceil(ms / (1000 * 60));
+        if (minutes < 60) {
+            return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+        }
+        const hours = Math.ceil(ms / (1000 * 60 * 60));
+        if (hours < 24) {
+            return `${hours} hour${hours === 1 ? '' : 's'}`;
+        }
+        const days = Math.ceil(ms / (1000 * 60 * 60 * 24));
+        return `${days} day${days === 1 ? '' : 's'}`;
+    },
+
+    // Short label for countdown timer
+    formatDurationShort: (ms) => {
+        const minutes = Math.ceil(ms / (1000 * 60));
+        if (minutes < 60) return `${minutes}m`;
+        const hours = Math.ceil(ms / (1000 * 60 * 60));
+        if (hours < 24) return `${hours}h`;
+        const days = Math.ceil(ms / (1000 * 60 * 60 * 24));
+        return `${days}d`;
+    },
+
     // Debounce function
     debounce: (func, wait) => {
         let timeout;


### PR DESCRIPTION
## Summary
- make anti-cheat intervals easier to read by converting to hours and days
- scale anti-cheat cooldowns down by half
- add `formatDuration` helpers in `Utils`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68799d3698808331882c7aff7145e758