### PR TITLE
Remove cooldown display features

### DIFF
--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -77,8 +77,7 @@
                 tile.classList.add('locked');
                 tracker.showLockIcon(tile);
             } else if (validation.type === 'cooldown') {
-                tile.classList.add('on-cooldown');
-                tracker.showCooldownTimer(tile, validation.remainingTime);
+                // Cooldown visuals have been removed
             }
         }
     };
@@ -95,45 +94,6 @@
         }
     };
 
-    // NEW: Show countdown timer for challenges on cooldown
-    tracker.showCooldownTimer = function(tile, remainingTime) {
-        let timer = tile.querySelector('.timer-indicator');
-        if (!timer) {
-            timer = document.createElement('div');
-            timer.className = 'timer-indicator';
-            tile.appendChild(timer);
-        }
-        
-        const updateTimer = () => {
-            let label;
-            if (window.Utils && typeof Utils.formatDurationShort === 'function') {
-                label = Utils.formatDurationShort(remainingTime);
-            } else {
-                label = `${Math.ceil(remainingTime / (1000 * 60))}m`;
-            }
-            timer.textContent = label;
-            timer.style.display = 'block';
-            
-            remainingTime -= 1000;
-            if (remainingTime <= 0) {
-                timer.style.display = 'none';
-                tile.classList.remove('on-cooldown');
-                // Show unlock notification
-                tracker.showUnlockNotification();
-            } else {
-                setTimeout(updateTimer, 1000);
-            }
-        };
-        
-        updateTimer();
-    };
-
-    // NEW: Show notification when challenge unlocks
-    tracker.showUnlockNotification = function() {
-        if (window.Utils && Utils.showNotification) {
-            Utils.showNotification('✨ Challenge unlocked! You can try again now.', 'success');
-        }
-    };
 
     // NEW: Enhanced render grid to apply anti-cheat state
     const originalRenderGrid = tracker.renderGrid;

--- a/styles/global.css
+++ b/styles/global.css
@@ -1050,27 +1050,6 @@ body {
     border-radius: inherit;
 }
 
-/* Cooldown overlay for tiles */
-.bingo-tile.on-cooldown {
-    position: relative;
-    pointer-events: none;
-}
-
-.bingo-tile.on-cooldown::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(239, 68, 68, 0.2); /* red-500 with opacity */
-    border-radius: inherit;
-    z-index: 1;
-}
-
-.bingo-tile.on-cooldown .bingo-tile-text {
-    opacity: 0.6;
-}
 
 /* Event timeline indicator */
 .event-timeline {
@@ -1395,36 +1374,6 @@ body {
 }
 
 /* Cooldown State */
-.bingo-tile.on-cooldown {
-    background: rgba(239, 68, 68, 0.1) !important; /* red-500 with opacity */
-    border-color: #f87171 !important; /* red-400 */
-    cursor: wait;
-    position: relative;
-}
-
-.bingo-tile.on-cooldown::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(239, 68, 68, 0.1);
-    border-radius: inherit;
-    z-index: 1;
-    animation: cooldownPulse 2s infinite;
-}
-
-@keyframes cooldownPulse {
-    0%, 100% { opacity: 0.1; }
-    50% { opacity: 0.3; }
-}
-
-.bingo-tile.on-cooldown .bingo-tile-text {
-    opacity: 0.7;
-    position: relative;
-    z-index: 2;
-}
 
 /* Newly Unlocked Animation */
 .bingo-tile.newly-unlocked {
@@ -1738,11 +1687,6 @@ body {
         background: #cccccc !important;
     }
 
-    .bingo-tile.on-cooldown {
-        border-width: 3px !important;
-        border-color: #ff0000 !important;
-        background: #ffcccc !important;
-    }
 
     .timer-indicator {
         background: #000000 !important;
@@ -1790,16 +1734,14 @@ body {
         display: none !important;
     }
 
-    .bingo-tile.locked,
-    .bingo-tile.on-cooldown {
+    .bingo-tile.locked {
         opacity: 0.3;
         filter: none;
     }
 }
 
 /* Accessibility Improvements */
-.bingo-tile.locked:focus,
-.bingo-tile.on-cooldown:focus {
+.bingo-tile.locked:focus {
     outline: 2px solid #ef4444;
     outline-offset: 2px;
 }
@@ -1814,8 +1756,7 @@ body {
     transition: all 0.3s ease;
 }
 
-.bingo-tile.locked,
-.bingo-tile.on-cooldown {
+.bingo-tile.locked {
     transition: all 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- strip cooldown styling rules from `global.css`
- remove cooldown timer helpers in `bingo-anticheat-integration.js`
- stop adding the `on-cooldown` class when rendering tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879a4692b248331b74317b0887b33e3