### PR TITLE
Show overall completion percentage

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
 
                     <div class="total-points">
                         Total Points: <span id="total-points">0</span>
+                        (<span id="total-progress">0%</span> complete)
                     </div>
 
                     <!-- Anti-Cheat Status (initially hidden) -->

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -309,6 +309,23 @@ const BingoTracker = {
         return regular + completionist;
     },
 
+    // Calculate maximum possible points across both modes
+    getTotalPossiblePoints: () => {
+        let total = BINGO_CHALLENGES.length;
+        COMPLETIONIST_CHALLENGES.forEach(ch => {
+            const req = ch.requiredCount || (ch.sublist ? ch.sublist.length : 0);
+            total += req + 1;
+        });
+        return total;
+    },
+
+    // Overall completion percentage including sub items
+    getTotalProgressPercent: () => {
+        const achieved = BingoTracker.getTotalPoints();
+        const possible = BingoTracker.getTotalPossiblePoints();
+        return possible ? Math.round((achieved / possible) * 100) : 0;
+    },
+
     openSublist: (index) => {
         const challenge = COMPLETIONIST_CHALLENGES[index];
         const stored = BingoTracker.subItemProgress[index];
@@ -450,12 +467,14 @@ const BingoTracker = {
         const progressPercent = Math.round((completedCount / totalCount) * 100);
         const achievements = BingoTracker.countAchievements();
         const totalPoints = BingoTracker.getTotalPoints();
+        const totalProgress = BingoTracker.getTotalProgressPercent();
 
         const elements = {
             'completed-count': completedCount,
             'progress-percent': progressPercent + '%',
             'achievement-count': achievements,
-            'total-points': totalPoints
+            'total-points': totalPoints,
+            'total-progress': totalProgress + '%'
         };
         
         Object.entries(elements).forEach(([id, value]) => {

--- a/tests/bingo.test.js
+++ b/tests/bingo.test.js
@@ -16,3 +16,20 @@ test('getTotalPoints sums points from both modes', () => {
   const total = BingoTracker.getTotalPoints();
   expect(total).toBe(5); // 2 regular + (2 sub items + 1 tile)
 });
+
+test('getTotalProgressPercent reflects overall completion', () => {
+  const code = fs.readFileSync(path.join(__dirname, '../scripts/bingo.js'), 'utf8');
+  const context = { console };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  const BingoTracker = vm.runInContext('BingoTracker', context);
+
+  BingoTracker.completedTiles.regular = new Set([1]);
+  BingoTracker.completedTiles.completionist = new Set([0]);
+  BingoTracker.subItemProgress = { 0: { 0: true } };
+
+  const earned = BingoTracker.getTotalPoints();
+  const possible = BingoTracker.getTotalPossiblePoints();
+  const percent = BingoTracker.getTotalProgressPercent();
+  expect(percent).toBe(Math.round((earned / possible) * 100));
+});


### PR DESCRIPTION
## Summary
- show the total percent complete in the challenge header
- track maximum achievable points and expose overall completion percentage
- display overall percentage next to the total points
- test new progress percent calculation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879a4d1663c8331a038d29a01e8a728