### PR TITLE
Enforce unique usernames in Firebase

### DIFF
--- a/tests/leaderboard.test.js
+++ b/tests/leaderboard.test.js
@@ -24,6 +24,7 @@ describe('Leaderboard pending score handling', () => {
     class FailFirebaseLeaderboard {
       async init() { return false; }
       isAvailable() { return false; }
+      async isUsernameAvailable() { return true; }
       subscribeToLeaderboard() {}
     }
     window.FirebaseLeaderboard = FailFirebaseLeaderboard;
@@ -42,6 +43,7 @@ describe('Leaderboard pending score handling', () => {
       constructor() { this.initialized = false; this.submitted = []; window._fbInstance = this; }
       async init() { this.initialized = true; return true; }
       isAvailable() { return this.initialized; }
+      async isUsernameAvailable() { return true; }
       async submitScore(userId, username, score) { this.submitted.push({ userId, username, score }); }
       subscribeToLeaderboard() {}
     }


### PR DESCRIPTION
## Summary
- add FirebaseLeaderboard.isUsernameAvailable helper
- check username availability before storing scores
- warn users about taken usernames when picking a name
- adjust tests for new API

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879bae662548331a13339a526eb9593