### PR TITLE
Add username duplicate detection

### DIFF
--- a/scripts/username-feedback.js
+++ b/scripts/username-feedback.js
@@ -11,20 +11,48 @@ const UsernameFeedback = {
         }
         feedback.classList.add('hide');
 
-        const applyResult = () => {
+        const applyResult = async () => {
             const result = window.UsernameValidator.validateWithFeedback(input.value);
-            feedback.textContent = result.message;
-            if (!result.isValid && result.cleanUsername && result.cleanUsername !== input.value.trim()) {
+            let message = result.message;
+            let status = 'success';
+            let isValid = result.isValid;
+
+            if (isValid && window.Leaderboard &&
+                window.Leaderboard.firebaseLeaderboard &&
+                typeof window.Leaderboard.firebaseLeaderboard.isAvailable === 'function' &&
+                window.Leaderboard.firebaseLeaderboard.isAvailable()) {
+                try {
+                    const available = await window.Leaderboard.firebaseLeaderboard.isUsernameAvailable(
+                        input.value.trim(),
+                        window.Utils && typeof Utils.getUserId === 'function' ? Utils.getUserId() : undefined
+                    );
+                    if (!available) {
+                        message = 'Username already taken';
+                        status = 'error';
+                        isValid = false;
+                    }
+                } catch (err) {
+                    console.error('Username availability check failed:', err);
+                }
+            } else if (!isValid) {
+                status = result.message === 'Please choose a more appropriate username'
+                    ? 'warning'
+                    : 'error';
+            } else {
+                status = 'success';
+            }
+
+            feedback.textContent = message;
+            if (!isValid && result.cleanUsername && result.cleanUsername !== input.value.trim()) {
                 feedback.textContent += ` Using: "${result.cleanUsername}"`;
             }
             feedback.classList.remove('success', 'error', 'warning', 'hide');
             input.classList.remove('valid', 'invalid');
-            if (result.isValid) {
+            if (isValid) {
                 feedback.classList.add('show', 'success');
                 input.classList.add('valid');
             } else {
-                const blocked = result.message === 'Please choose a more appropriate username';
-                feedback.classList.add('show', blocked ? 'warning' : 'error');
+                feedback.classList.add('show', status === 'warning' ? 'warning' : 'error');
                 input.classList.add('invalid');
             }
         };

--- a/tests/username-feedback.test.js
+++ b/tests/username-feedback.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const vm = require('vm');
 const { JSDOM } = require('jsdom');
 
-test('displays warning when username is blocked', () => {
+test('displays warning when username is blocked', async () => {
   const dom = new JSDOM('<!DOCTYPE html><div id="username-container"><input id="username"></div>');
   const context = {
     window: dom.window,
@@ -29,9 +29,51 @@ test('displays warning when username is blocked', () => {
   const input = dom.window.document.getElementById('username');
   input.value = 'bad';
   input.dispatchEvent(new dom.window.Event('input'));
+  await new Promise(r => setImmediate(r));
 
   const feedback = dom.window.document.getElementById('username-feedback');
   expect(feedback.textContent).toBe('Please choose a more appropriate username Using: "Clean"');
   expect(feedback.classList.contains('warning')).toBe(true);
+  expect(input.classList.contains('invalid')).toBe(true);
+});
+
+test('shows error when username is taken', async () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="username-container"><input id="username"></div>');
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    console,
+    Utils: { debounce: fn => fn, getUserId: () => 'u1' },
+    UsernameValidator: {
+      validateWithFeedback: jest.fn(() => ({
+        isValid: true,
+        cleanUsername: 'Alice',
+        message: 'Username looks good!'
+      }))
+    },
+    Leaderboard: {
+      firebaseLeaderboard: {
+        isAvailable: () => true,
+        isUsernameAvailable: jest.fn(() => Promise.resolve(false))
+      }
+    }
+  };
+  context.window.Utils = context.Utils;
+  context.window.UsernameValidator = context.UsernameValidator;
+  context.window.Leaderboard = context.Leaderboard;
+
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, '../scripts/username-feedback.js'), 'utf8');
+  vm.runInContext(code, context);
+
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  const input = dom.window.document.getElementById('username');
+  input.value = 'Alice';
+  input.dispatchEvent(new dom.window.Event('input'));
+  await new Promise(r => setImmediate(r));
+
+  const feedback = dom.window.document.getElementById('username-feedback');
+  expect(feedback.textContent).toBe('Username already taken');
+  expect(feedback.classList.contains('error')).toBe(true);
   expect(input.classList.contains('invalid')).toBe(true);
 });


### PR DESCRIPTION
## Summary
- check username availability while typing
- surface 'username already taken' message via new test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c0292f248331995fa5dccb947022