### PR TITLE
Fix leaderboard update when score resets

### DIFF
--- a/scripts/firebase-leaderboard.js
+++ b/scripts/firebase-leaderboard.js
@@ -106,15 +106,26 @@ class FirebaseLeaderboard {
             }
 
             if (!snapshot.empty) {
-                // Update existing entry
                 const docRef = snapshot.docs[0];
-                await updateDoc(doc(this.db, 'leaderboard', docRef.id), {
-                    username: cleanUsername,
-                    score: score,
-                    lastUpdated: new Date().toISOString()
-                });
-                console.log('Score updated in Firebase for user:', userId);
+
+                if (score <= 0) {
+                    await deleteDoc(doc(this.db, 'leaderboard', docRef.id));
+                    console.log('Score removed from Firebase for user:', userId);
+                } else {
+                    // Update existing entry
+                    await updateDoc(doc(this.db, 'leaderboard', docRef.id), {
+                        username: cleanUsername,
+                        score: score,
+                        lastUpdated: new Date().toISOString()
+                    });
+                    console.log('Score updated in Firebase for user:', userId);
+                }
             } else {
+                if (score <= 0) {
+                    // Nothing to save when score is zero
+                    return true;
+                }
+
                 // Create new entry
                 await addDoc(leaderboardRef, {
                     userId: userId,

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -240,12 +240,10 @@ const Leaderboard = {
         
         if (window.BingoTracker && BingoTracker.completedTiles) {
             const completedCount = BingoTracker.completedTiles[BingoTracker.currentMode || 'regular'].size;
-            if (completedCount > 0) {
-                try {
-                    await Leaderboard.saveScore(userId, username, completedCount);
-                } catch (error) {
-                    console.error('Failed to save current progress:', error);
-                }
+            try {
+                await Leaderboard.saveScore(userId, username, completedCount);
+            } catch (error) {
+                console.error('Failed to save current progress:', error);
             }
         }
     },
@@ -522,6 +520,17 @@ Leaderboard.saveScore = async (userId, username, score) => {
             Utils.showNotification('Invalid score detected. Please refresh and try again.', 'error');
         }
         return false;
+    }
+
+    if (score <= 0 && Leaderboard.firebaseLeaderboard && Leaderboard.firebaseLeaderboard.isAvailable()) {
+        try {
+            await Leaderboard.firebaseLeaderboard.deleteUserScore(cleanUserId);
+            console.log('Removed user from leaderboard:', cleanUserId);
+            return true;
+        } catch (err) {
+            console.error('Failed to remove user score:', err);
+            return false;
+        }
     }
 
     // Proceed with original save if validation passes


### PR DESCRIPTION
## Summary
- handle zero scores when writing to Firestore
- always save progress even if score is zero
- remove leaderboard entry when score resets to zero
- test that zero scores remove the leaderboard entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a746602a8833183b555adae24bdc1