### PR TITLE
Restrict communion challenge availability

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -91,6 +91,12 @@ const AntiCheatSystem = {
         if (dayOfEvent > 7) return true;
 
         if (mode === 'regular') {
+            // Communion challenge only on Wednesday during the event
+            if (index === 7) {
+                const isWednesday = new Date().getDay() === 3; // 0=Sun,3=Wed
+                return isWednesday;
+            }
+
             // Regular challenges unlock progressively
             return dayOfEvent >= 1;
         } else if (mode === 'completionist') {

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -27,4 +27,19 @@ describe('challenge availability schedule', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
     expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
   });
+
+  test('communion challenge only available on Wednesday', () => {
+    jest.useFakeTimers();
+    // Monday of event
+    jest.setSystemTime(new Date('2025-07-21T10:00:00Z'));
+    AntiCheat.eventConfig.getDayOfEvent = () => 5;
+    expect(AntiCheat.isChallengeAvailable('regular', 7)).toBe(false);
+
+    // Wednesday of event
+    jest.setSystemTime(new Date('2025-07-23T10:00:00Z'));
+    AntiCheat.eventConfig.getDayOfEvent = () => 7;
+    expect(AntiCheat.isChallengeAvailable('regular', 7)).toBe(true);
+
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- enforce Wednesday-only availability for the communion challenge in the anti-cheat system
- cover the new restriction with unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a7e0660288331a1978898d5828e47