### PR TITLE
Update Saturday mass event challenge

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -91,6 +91,12 @@ const AntiCheatSystem = {
         if (dayOfEvent > 7) return true;
 
         if (mode === 'regular') {
+            // Special lock for Saturday mass event (tile index 2)
+            if (index === 2) {
+                const unlockTime = new Date(this.eventConfig.startDate.getTime() + (2 * 24 + 20) * 60 * 60 * 1000);
+                return new Date() >= unlockTime;
+            }
+
             // Regular challenges unlock progressively
             return dayOfEvent >= 1;
         } else if (mode === 'completionist') {

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -3,7 +3,7 @@
 const BINGO_CHALLENGES = [
     "Take a selfie with a Martin Luther figure or picture",
     "Learn someone's name from a different state",
-    "Attend the opening worship service",
+    "Attend the Saturday mass event",
     "Visit 3 different exhibitor booths",
     "Participate in a service project",
     "Do the chicken dance with someone from another group",

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -5,6 +5,7 @@ describe('challenge availability schedule', () => {
 
   afterEach(() => {
     AntiCheat.eventConfig.getDayOfEvent = originalGetDay;
+    jest.useRealTimers();
   });
 
   test('convention center games unlock on day 3', () => {
@@ -26,5 +27,18 @@ describe('challenge availability schedule', () => {
   test('daily acts of kindness available from start', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
     expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
+  });
+
+  test('Saturday mass event locked until 8pm', () => {
+    const originalStart = AntiCheat.eventConfig.startDate;
+    AntiCheat.eventConfig.startDate = new Date('2025-07-17T00:00:00');
+
+    jest.useFakeTimers().setSystemTime(new Date('2025-07-19T19:00:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(false);
+
+    jest.setSystemTime(new Date('2025-07-19T20:00:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
+
+    AntiCheat.eventConfig.startDate = originalStart;
   });
 });


### PR DESCRIPTION
## Summary
- change the opening worship bingo challenge to read "Attend the Saturday mass event"
- lock that challenge until 8pm on Saturday in `anti-cheat-system`
- test the Saturday mass event unlock time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7ec7109883318cd615b37ce397c5