### PR TITLE
Update challenge text and add time lock

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -34,7 +34,7 @@ const AntiCheatSystem = {
         this.minimumIntervals.set('regular', new Map([
             [0, 15],   // Selfie with Martin Luther figure - 15 min
             [1, 30],   // Learn someone's name - 30 min
-            [2, 5],    // Attend opening worship - 5 min
+            [2, 5],    // Attend the Saturday mass event - 5 min
             [3, 20],   // Visit 3 booths - 20 min
             [4, 45],   // Service project - 45 min
             [5, 10],   // Chicken dance - 10 min
@@ -91,6 +91,14 @@ const AntiCheatSystem = {
         if (dayOfEvent > 7) return true;
 
         if (mode === 'regular') {
+            // Saturday mass event only available after 8pm Saturday
+            if (index === 2) {
+                const massDate = new Date(this.eventConfig.startDate);
+                massDate.setDate(massDate.getDate() + 2); // Saturday of event
+                massDate.setHours(20, 0, 0, 0); // 8 PM
+                return new Date() >= massDate;
+            }
+
             // Communion challenge only on Wednesday during the event
             if (index === 7) {
                 const isWednesday = new Date().getDay() === 3; // 0=Sun,3=Wed

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -3,7 +3,7 @@
 const BINGO_CHALLENGES = [
     "Take a selfie with a Martin Luther figure or picture",
     "Learn someone's name from a different state",
-    "Attend the opening worship service",
+    "Attend the Saturday mass event",
     "Visit 3 different exhibitor booths",
     "Participate in a service project",
     "Do the chicken dance with someone from another group",


### PR DESCRIPTION
## Summary
- rename opening worship challenge to Saturday mass event
- lock challenge until 8pm Saturday during the event

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a806614d48331abd5f5d1da472be0