### PR TITLE
Fix Day 1 detection

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -10,7 +10,7 @@ const AntiCheatSystem = {
     
     // NEW: Event date configuration
     eventConfig: {
-        startDate: new Date('2025-07-17T00:00:00'), // July 17, 2025
+        startDate: new Date('2025-07-18T00:00:00'), // July 18, 2025
         endDate: new Date('2025-07-25T23:59:59'),   // July 25, 2025
         isEventActive: function() {
             const now = new Date();

--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -29,7 +29,7 @@
                 if (validation.type === 'temporal_lock') {
                     const eventStatus = ac.getEventStatus();
                     if (eventStatus.dayOfEvent < 1) {
-                        message = `Challenges unlock on July 17th, 2025! Check back during the Youth Gathering.`;
+                        message = `Challenges unlock on July 18th, 2025! Check back during the Youth Gathering.`;
                     } else if (mode === 'completionist') {
                         message = `This Hard Mode challenge unlocks later in the event. Keep checking back!`;
                     }
@@ -136,7 +136,7 @@
                 const daysUntil = Math.ceil((ac.eventConfig.startDate - new Date()) / (1000 * 60 * 60 * 24));
                 statusContainer.innerHTML = `
                     <div class="text-center text-blue-600">
-                        ⏰ Challenges unlock in ${daysUntil} days (July 17th)
+                        ⏰ Challenges unlock in ${daysUntil} days (July 18th)
                     </div>
                 `;
             } else {

--- a/scripts/event-status.js
+++ b/scripts/event-status.js
@@ -34,7 +34,7 @@ async function loadEventStatus() {
 function getLocalEventData() {
     // Use the same event configuration as anti-cheat system
     const now = new Date();
-    const startDate = new Date('2025-07-17T00:00:00');
+    const startDate = new Date('2025-07-18T00:00:00');
     const endDate = new Date('2025-07-25T23:59:59');
     
     const isActive = now >= startDate && now <= endDate;
@@ -52,7 +52,7 @@ function getLocalEventData() {
     } else if (isUpcoming) {
         const daysUntil = Math.ceil((startDate - now) / (1000 * 60 * 60 * 24));
         status = 'Upcoming';
-        message = `Challenges unlock in ${daysUntil} days (July 17th, 2025)`;
+        message = `Challenges unlock in ${daysUntil} days (July 18th, 2025)`;
     } else {
         status = 'Concluded';
         message = 'Youth Gathering 2025 has concluded';


### PR DESCRIPTION
## Summary
- set Youth Gathering start date to July 18, 2025
- update messages referencing July 17 to July 18

## Testing
- `npm test --silent`
- `node -e "const ac=require('./scripts/anti-cheat-system'); console.log('Day of event:', ac.eventConfig.getDayOfEvent());"`

------
https://chatgpt.com/codex/tasks/task_e_687a88fdf3f483319e0307064d6a62b7