### PR TITLE
Replace worship service text with mass event

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -69,7 +69,7 @@ const AntiCheatSystem = {
             [5, 36],   // Thank 10 volunteers - 1.5 days
             [6, 24],   // 3+ service opportunities - 1 day
             [7, 48],   // All speaker autographs - 2 days
-            [8, 168],  // Every worship service - 7 days
+            [8, 168],  // Each mass event - 7 days
             [9, 12],   // Lead prayer circle - 12 hours
             [10, 72],  // 25+ new friends - 3 days
             [11, 168], // Daily acts of kindness - 7 days

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -67,7 +67,7 @@ const COMPLETIONIST_CHALLENGES = [
     { text: 'Volunteer for 3+ service opportunities', sublist: Array.from({length:3},(_,i)=>`Service ${i+1}`) },
     { text: 'Exchange contacts with 25+ new friends', sublist: Array.from({length:25},(_,i)=>`Friend ${i+1}`), freeText: true },
     { text: 'Complete daily random acts of kindness', sublist: Array.from({length:7},(_,i)=>`Day ${i+1}`), freeText: true },
-    { text: 'Participate in every worship service', sublist: Array.from({length:5},(_,i)=>`Service ${i+1}`), freeText: true },
+    { text: 'Attend each mass event', sublist: Array.from({length:5},(_,i)=>`Event ${i+1}`), freeText: true },
     { text: 'Attend 15+ sessions/workshops', sublist: [], requiredCount: 15, enableSearch: true },
     { text: 'Get autographs from all guest speakers', sublist: Array.from({length:5},(_,i)=>`Speaker ${i+1}`), freeText: true },
     { text: 'Get photos with all main speakers', sublist: ['Shelly Schwalm', 'Tanner Olsen', 'Brady Finnern'] },


### PR DESCRIPTION
## Summary
- update Bingo challenge text from worship services to mass events
- tweak anti-cheat comment to reference mass events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8a13ae488331b8dc0ca0f505ff01