### PR TITLE
Allow hair color hardmode from Day 1

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -117,6 +117,10 @@ const AntiCheatSystem = {
                 // Sessions/workshops and exhibitor booths open Sunday (Day 4)
                 return dayOfEvent >= 4;
             }
+            if (index === 15) {
+                // Hair color challenge available from the start
+                return dayOfEvent >= 1;
+            }
             if (index === 7) {
                 // Daily acts of kindness available from the start
                 return dayOfEvent >= 1;

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -28,6 +28,11 @@ describe('challenge availability schedule', () => {
     expect(AntiCheat.isChallengeAvailable('completionist', 7)).toBe(true);
   });
 
+  test('hair color challenge available from day 1', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
+  });
+
   test('communion challenge only available on Wednesday', () => {
     jest.useFakeTimers();
     // Monday of event


### PR DESCRIPTION
## Summary
- remove temporal lock for the hair color challenge
- check hair color challenge availability from Day 1
- test for hair color challenge always available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9c75d27483319cc0a7039ece70dc