### PR TITLE
Replace missions challenge with poll

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -42,7 +42,7 @@ const AntiCheatSystem = {
             [7, 5],    // Take communion - 5 min
             [8, 15],   // Ask speaker question - 15 min
             [9, 60],   // Exchange contact info - 60 min
-            [10, 30],  // Attend breakout session - 30 min
+            [10, 30],  // Complete the Gathering poll - 30 min
             [11, 20],  // Pray with someone - 20 min
             [12, 15],  // Sample New Orleans cuisine - 15 min
             [13, 10],  // Group photo - 10 min

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -11,7 +11,7 @@ const BINGO_CHALLENGES = [
     "Take communion at morning worship",
     "Ask a speaker a question during Q&A",
     "Exchange contact info with 5 new friends",
-    "Attend a breakout session on missions",
+    "Complete the Gathering poll",
     "Pray with someone you just met",
     "Sample some classic New Orleans cuisine",
     "Take a group photo with your youth group",


### PR DESCRIPTION
## Summary
- reword "Attend a breakout session on missions" challenge to "Complete the Gathering poll"
- update anti-cheat comment to match new challenge

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa5a294908331ad7d3deb18884bb0