### PR TITLE
Implement timed mass event release

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -91,12 +91,14 @@ const AntiCheatSystem = {
         if (dayOfEvent > 7) return true;
 
         if (mode === 'regular') {
-            // Saturday mass event only available after 8pm Saturday
+            // Mass event challenge unlocks nightly at 7:30pm CT
             if (index === 2) {
-                const massDate = new Date(this.eventConfig.startDate);
-                massDate.setDate(massDate.getDate() + 2); // Saturday of event
-                massDate.setHours(20, 0, 0, 0); // 8 PM
-                return new Date() >= massDate;
+                const now = new Date();
+                if (now < this.eventConfig.startDate) return false;
+                const centralNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
+                const unlock = new Date(centralNow);
+                unlock.setHours(19, 30, 0, 0); // 7:30 PM Central
+                return centralNow >= unlock;
             }
 
             // Communion challenge only on Wednesday during the event

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -47,4 +47,14 @@ describe('challenge availability schedule', () => {
 
     jest.useRealTimers();
   });
+
+  test('mass event challenge unlocks at 7:30pm CT', () => {
+    jest.useFakeTimers();
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    jest.setSystemTime(new Date('2025-07-18T19:29:00-05:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(false);
+    jest.setSystemTime(new Date('2025-07-18T19:31:00-05:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- unlock the mass event challenge nightly at 7:30 PM Central
- gate each mass event subtask until its release time
- test the mass event unlock logic

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_687ba0e8846083318c6f735dcea7227f