### PR TITLE
Disable free text on hair color challenge

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -113,8 +113,7 @@ const COMPLETIONIST_CHALLENGES = [
     ] },
     { text: 'Visit every exhibitor booth', sublist: Array.from({length:50},(_,i)=>`Booth ${i+1}`) },
     { text: 'Meet someone with different hair colors',
-      sublist: ['Brown', 'Blonde', 'Black', 'Red', 'Pink', 'Green', 'Bald'],
-      freeText: true }
+      sublist: ['Brown', 'Blonde', 'Black', 'Red', 'Pink', 'Green', 'Bald'] }
 ];
 
 const BingoTracker = {


### PR DESCRIPTION
## Summary
- restrict the "hair colors" completionist challenge to the built-in list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bfc4b32288331aa0c5526045e6a6f