### PR TITLE
Remove game challenge time lock

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -112,8 +112,8 @@ const AntiCheatSystem = {
         } else if (mode === 'completionist') {
             // Custom unlock schedule for certain challenges
             if (index === 12) {
-                // Convention center games start Saturday (Day 3)
-                return dayOfEvent >= 3;
+                // Convention center game challenge available for the entire event
+                return dayOfEvent >= 1;
             }
             if (index === 9 || index === 14) {
                 // Sessions/workshops and exhibitor booths open Sunday (Day 4)

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -7,9 +7,9 @@ describe('challenge availability schedule', () => {
     AntiCheat.eventConfig.getDayOfEvent = originalGetDay;
   });
 
-  test('convention center games unlock on day 3', () => {
-    AntiCheat.eventConfig.getDayOfEvent = () => 2;
-    expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(false);
+  test('convention center games available from day 1', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(true);
     AntiCheat.eventConfig.getDayOfEvent = () => 3;
     expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- unlock the 'compete in every convention center game' challenge from day 1
- update tests for new availability schedule

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c24ce130883318a326f82397c821f