### PR TITLE
Remove time gate from social media friend challenge

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -123,6 +123,10 @@ const AntiCheatSystem = {
                 // Hair color challenge available from the start
                 return dayOfEvent >= 1;
             }
+            if (index === 6) {
+                // Social media friend challenge available from the start
+                return dayOfEvent >= 1;
+            }
             if (index === 7) {
                 // Daily acts of kindness available from the start
                 return dayOfEvent >= 1;


### PR DESCRIPTION
## Summary
- allow the completionist challenge "Exchange contact info with 25+ new friends" to be available from the start of the event

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c2ff95f288331adff7749dff25ff4