### PR TITLE
Fix hard mode game challenge

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -87,8 +87,7 @@ const COMPLETIONIST_CHALLENGES = [
         'Hungry hungry hippos',
         'Twister',
         'Giant Uno'
-      ],
-      freeText: true },
+      ] },
     { text: 'Collect all district booth prizes', sublist: [
         'Atlantic District',
         'California–Nevada–Hawaii District',


### PR DESCRIPTION
## Summary
- make the "Compete in every convention center game" challenge use button selections instead of text inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c3304dadc8331a2babdcdda3b62a0