### PR TITLE
Unlock mass event hard mode challenge

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -115,6 +115,10 @@ const AntiCheatSystem = {
                 // Convention center game challenge available for the entire event
                 return dayOfEvent >= 1;
             }
+            if (index === 8) {
+                // Mass event hard mode challenge should be available from the start
+                return dayOfEvent >= 1;
+            }
             if (index === 9 || index === 14) {
                 // Sessions/workshops and exhibitor booths open Sunday (Day 4)
                 return dayOfEvent >= 4;

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -33,6 +33,11 @@ describe('challenge availability schedule', () => {
     expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
   });
 
+  test('mass event hard mode challenge available from day 1', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(true);
+  });
+
   test('communion challenge only available on Wednesday', () => {
     jest.useFakeTimers();
     // Monday of event


### PR DESCRIPTION
## Summary
- unlock mass event hard mode challenge from start of event
- test that mass event challenge is available on day 1

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c71434090833195dad0467decfdcd