### PR TITLE
Unlock daily photo challenge from day 1

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -131,6 +131,10 @@ const AntiCheatSystem = {
                 // Daily acts of kindness available from the start
                 return dayOfEvent >= 1;
             }
+            if (index === 10) {
+                // Daily photo challenge available from the start
+                return dayOfEvent >= 1;
+            }
 
             // Default: unlock groups of three each day
             const unlockDay = Math.floor(index / 3) + 1;


### PR DESCRIPTION
## Summary
- allow the "Daily photo challenge" completionist tile to be available starting on day 1

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c71b96de0833198f85fda798e6653