### PR TITLE
Expand leaderboard to show top 100

### DIFF
--- a/gathertogether-backend/routes/bingo.js
+++ b/gathertogether-backend/routes/bingo.js
@@ -18,14 +18,14 @@ router.get('/leaderboard', async (req, res) => {
       const leaderboard = rows
         .map(r => ({ id: r[0], playerName: r[1], score: parseInt(r[2], 10) || 0 }))
         .sort((a, b) => b.score - a.score)
-        .slice(0, 50);
+        .slice(0, 100);
       return res.json(leaderboard);
     }
 
     const leaderboardSnapshot = await db
       .collection('leaderboard') // <-- CHANGED
       .orderBy('score', 'desc')
-      .limit(50)
+      .limit(100)
       .get();
 
     const leaderboard = [];

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
                     <div id="leaderboard" class="hidden mt-8">
                         <div class="flex justify-between items-center mb-4">
-                            <h2 class="text-3xl font-bold text-gray-800">Top 25 Leaders</h2>
+                            <h2 class="text-3xl font-bold text-gray-800">Top 100 Leaders</h2>
                             <button onclick="Leaderboard.refresh()" class="btn-secondary btn-compact">Refresh</button>
                         </div>
                         <ul id="leaderboard-list" class="space-y-1 text-sm max-w-md mx-auto"></ul>

--- a/scripts/leaderboard.js
+++ b/scripts/leaderboard.js
@@ -185,7 +185,7 @@ const Leaderboard = {
         if (Leaderboard.firebaseLeaderboard && Leaderboard.firebaseLeaderboard.isAvailable()) {
             Leaderboard.showLoading();
             try {
-                const scores = await Leaderboard.firebaseLeaderboard.getTopScores(25);
+                const scores = await Leaderboard.firebaseLeaderboard.getTopScores(100);
                 Leaderboard.renderLeaderboard(scores);
                 return true;
             } catch (error) {
@@ -289,7 +289,7 @@ const Leaderboard = {
         // Sort by score descending (in case not sorted)
         const sortedLeaderboard = [...filteredLeaderboard]
             .sort((a, b) => b.score - a.score)
-            .slice(0, 25);
+            .slice(0, 100);
 
         // FIX: Get current user ID to identify their entry
         const currentUserId = window.Utils && typeof Utils.getUserId === 'function'

--- a/server.js
+++ b/server.js
@@ -204,7 +204,7 @@ function getLeaderboard() {
       updatedAt: p.updatedAt || new Date().toISOString()
     }))
     .sort((a, b) => b.score - a.score)
-    .slice(0, 50); // Top 50 players
+    .slice(0, 100); // Top 100 players
   
   console.log('Current leaderboard:', leaderboard);
   return leaderboard;


### PR DESCRIPTION
## Summary
- increase leaderboard display size from 25 to 100 entries
- update backend APIs to return up to 100 scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c7285d43483319c3e62cb12f9a26f