### PR TITLE
Update mass event challenge list

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -69,7 +69,14 @@ const COMPLETIONIST_CHALLENGES = [
     { text: 'Volunteer for 3+ service opportunities', sublist: Array.from({length:3},(_,i)=>`Service ${i+1}`) },
     { text: 'Exchange contact info with 25+ new friends (add them on social media)', sublist: Array.from({length:25},(_,i)=>`Friend ${i+1}`), freeText: true },
     { text: 'Complete daily random acts of kindness', sublist: Array.from({length:7},(_,i)=>`Day ${i+1}`), freeText: true },
-    { text: 'Attend each mass event', sublist: Array.from({length:5},(_,i)=>`Event ${i+1}`), freeText: true },
+    { text: 'Attend each mass event',
+      sublist: [
+        'Saturday',
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday Worship'
+      ] },
     { text: 'Attend 15+ sessions/workshops', sublist: [], requiredCount: 15, enableSearch: true },
     { text: 'Complete the photo challenges for each day', sublist: Array.from({length:5},(_,i)=>`Day ${i+1}`), freeText: true },
     { text: 'Get photos with all main speakers', sublist: ['Shelly Schwalm', 'Tanner Olsen', 'Brady Finnern'] },


### PR DESCRIPTION
## Summary
- update mass event sub-challenges with fixed day names

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c77a2a1d48331b2770b5780462068