### PR TITLE
Unlock speakers challenge from start

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -139,6 +139,10 @@ const AntiCheatSystem = {
                 // Daily photo challenge available from the start
                 return dayOfEvent >= 1;
             }
+            if (index === 11) {
+                // Photos with main speakers available from the start
+                return dayOfEvent >= 1;
+            }
 
             // Default: unlock groups of three each day
             const unlockDay = Math.floor(index / 3) + 1;

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -33,6 +33,11 @@ describe('challenge availability schedule', () => {
     expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
   });
 
+  test('photos with main speakers available from day 1', () => {
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
+  });
+
   test('mass event hard mode challenge available from day 1', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
     expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(true);


### PR DESCRIPTION
## Summary
- remove day gating for taking photos with the main speakers
- test that speaker photo challenge is available on day 1

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c78ee817c8331b93a66e695e7d8de