### PR TITLE
Update mass event hard mode challenge

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -76,7 +76,8 @@ const COMPLETIONIST_CHALLENGES = [
         'Monday',
         'Tuesday',
         'Wednesday Worship'
-      ] },
+      ],
+      freeText: false },
     { text: 'Attend 15+ sessions/workshops', sublist: [], requiredCount: 15, enableSearch: true },
     { text: 'Complete the photo challenges for each day', sublist: Array.from({length:5},(_,i)=>`Day ${i+1}`), freeText: true },
     { text: 'Get photos with all main speakers', sublist: ['Shelly Schwalm', 'Tanner Olsen', 'Brady Finnern'] },


### PR DESCRIPTION
## Summary
- ensure mass event hard mode uses button clicks instead of text entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c7a520bb083319cf7971adc6d78ec