### PR TITLE
Implement time-gated mass event hard mode

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -116,8 +116,12 @@ const AntiCheatSystem = {
                 return dayOfEvent >= 1;
             }
             if (index === 8) {
-                // Mass event hard mode challenge should be available from the start
-                return dayOfEvent >= 1;
+                // Mass event hard mode unlocks at 7:30pm CT on day 1
+                const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
+                if (nowCentral < this.eventConfig.startDate) return false;
+                if (dayOfEvent > 1) return true;
+                const diffHours = (nowCentral - this.eventConfig.startDate) / (1000 * 60 * 60);
+                return diffHours >= 19.5;
             }
             if (index === 9 || index === 14) {
                 // Sessions/workshops and exhibitor booths open Sunday (Day 4)

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -367,6 +367,7 @@ const BingoTracker = {
 
         const isKindness = index === DAILY_KINDNESS_INDEX;
         const isMassEvent = index === MASS_EVENT_INDEX;
+        const centralNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
         const getMassUnlockTime = (offset) => {
             const base = window.AntiCheatSystem ? new Date(window.AntiCheatSystem.eventConfig.startDate) : new Date();
             base.setDate(base.getDate() + offset);
@@ -379,7 +380,7 @@ const BingoTracker = {
             if (isKindness) {
                 unlocked = dayOfEvent > i;
             } else if (isMassEvent) {
-                unlocked = new Date() >= getMassUnlockTime(i);
+                unlocked = centralNow >= getMassUnlockTime(i);
             }
             if (challenge.freeText) {
                 const val = progress[i] || '';
@@ -411,7 +412,8 @@ const BingoTracker = {
                     }
                     return;
                 }
-                if (isMassEvent && new Date() < getMassUnlockTime(sub)) {
+                const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
+                if (isMassEvent && nowCentral < getMassUnlockTime(sub)) {
                     if (window.Utils && Utils.showNotification) {
                         Utils.showNotification('This mass event unlocks at 7:30 PM CT.', 'warning');
                     }
@@ -447,7 +449,8 @@ const BingoTracker = {
                     e.target.value = progress[sub] || '';
                     return;
                 }
-                if (isMassEvent && new Date() < getMassUnlockTime(sub)) {
+                const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
+                if (isMassEvent && nowCentral < getMassUnlockTime(sub)) {
                     if (window.Utils && Utils.showNotification) {
                         Utils.showNotification('This mass event unlocks at 7:30 PM CT.', 'warning');
                     }

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -38,9 +38,14 @@ describe('challenge availability schedule', () => {
     expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
   });
 
-  test('mass event hard mode challenge available from day 1', () => {
+  test('mass event hard mode challenge unlocks at 7:30pm CT', () => {
+    jest.useFakeTimers();
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    jest.setSystemTime(new Date('2025-07-18T19:29:00-05:00'));
+    expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(false);
+    jest.setSystemTime(new Date('2025-07-18T19:31:00-05:00'));
     expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(true);
+    jest.useRealTimers();
   });
 
   test('communion challenge only available on Wednesday', () => {


### PR DESCRIPTION
## Summary
- enforce 7:30PM CT release for mass event hard mode
- respect central time when checking sublist unlocks
- update availability test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c7de8ee388331906858a99000d524