### PR TITLE
Adjust anti-cheat thresholds

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -7,6 +7,9 @@ const AntiCheatSystem = {
     lastActions: {},
     minimumIntervals: new Map(),
     userCompletionTimes: new Map(),
+    // Limit for bulk logging
+    actionWindowMs: 10 * 60 * 1000, // 10 minutes
+    maxActionsPerWindow: 50,
     
     // NEW: Event date configuration
     eventConfig: {
@@ -169,12 +172,12 @@ const AntiCheatSystem = {
             this.lastActions[userId] = [];
         }
         
-        // Clean old actions (older than 10 minutes)
-        const tenMinutesAgo = now - (10 * 60 * 1000);
-        this.lastActions[userId] = this.lastActions[userId].filter(t => t > tenMinutesAgo);
+        // Clean old actions based on configured window
+        const windowAgo = now - this.actionWindowMs;
+        this.lastActions[userId] = this.lastActions[userId].filter(t => t > windowAgo);
 
-        // Check for too many rapid completions within the 10 minute window
-        if (this.lastActions[userId].length > 25) {
+        // Check for too many rapid completions within the window
+        if (this.lastActions[userId].length >= this.maxActionsPerWindow) {
             this.flagUser(userId, 'Too many rapid completions');
             return {
                 allowed: false,

--- a/tests/anti-cheat-rate.test.js
+++ b/tests/anti-cheat-rate.test.js
@@ -1,0 +1,28 @@
+const AntiCheat = require('../scripts/anti-cheat-system');
+
+describe('rapid completion rate limiting', () => {
+  beforeEach(() => {
+    // reset tracking
+    AntiCheat.flaggedUsers.clear();
+    AntiCheat.lastActions = {};
+    // allow all challenges
+    AntiCheat.isChallengeAvailable = () => true;
+  });
+
+  test('bulk logging within limit does not flag', () => {
+    const user = 'bulkUser';
+    for (let i = 0; i < 30; i++) {
+      const res = AntiCheat.recordTileCompletion(user, i);
+      expect(res.allowed).toBe(true);
+    }
+    expect(AntiCheat.flaggedUsers.has(user)).toBe(false);
+  });
+
+  test('excessive rapid logging is flagged', () => {
+    const user = 'cheater';
+    for (let i = 0; i < AntiCheat.maxActionsPerWindow + 1; i++) {
+      AntiCheat.recordTileCompletion(user, i);
+    }
+    expect(AntiCheat.flaggedUsers.has(user)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- make the rapid completion limit configurable and less aggressive
- add tests covering the rate limiting behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ce711ea24833187f5efbc2c7db022