### PR TITLE
Lock Mass Event Plus until 10pm

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -110,6 +110,16 @@ const AntiCheatSystem = {
                 return isWednesday;
             }
 
+            // Mass Event Plus challenge unlocks nightly at 10:00pm CT
+            if (index === 16) {
+                const now = new Date();
+                if (now < this.eventConfig.startDate) return false;
+                const centralNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
+                const unlock = new Date(centralNow);
+                unlock.setHours(22, 0, 0, 0); // 10:00 PM Central
+                return centralNow >= unlock;
+            }
+
             // Regular challenges unlock progressively
             return dayOfEvent >= 1;
         } else if (mode === 'completionist') {

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -72,4 +72,14 @@ describe('challenge availability schedule', () => {
     expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
     jest.useRealTimers();
   });
+
+  test('mass event plus challenge unlocks at 10pm CT', () => {
+    jest.useFakeTimers();
+    AntiCheat.eventConfig.getDayOfEvent = () => 1;
+    jest.setSystemTime(new Date('2025-07-18T21:59:00-05:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 16)).toBe(false);
+    jest.setSystemTime(new Date('2025-07-18T22:01:00-05:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 16)).toBe(true);
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- enforce new 10pm CT unlock time for Mass Event Plus
- test the new unlock rule

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ce90954048331a52a6ea8ad0feddf