### PR TITLE
Add Hard Mode challenge module

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,10 @@
                         </div>
                     </div>
 
+                    <div id="hardmode-progress" class="hidden my-4 text-center">
+                        Hard Mode Sessions: <span id="hardmode-count">0</span>/15
+                    </div>
+
                     <div class="bingo-grid regular mb-6" id="bingo-grid">
                         <!-- Grid tiles will be populated by JavaScript -->
                     </div>
@@ -129,6 +133,7 @@
     <script src="scripts/anti-cheat-system.js?v=2"></script>
     <script src="scripts/bingo.js?v=2"></script>
     <script src="scripts/bingo-anticheat-integration.js?v=2"></script>
+    <script src="scripts/hardmode.js?v=2"></script>
     <script src="scripts/verse.js?v=2"></script>
     <script src="scripts/event-status.js?v=2"></script>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -32,6 +32,9 @@ const App = {
         // Initialize all modules
         App.setupEventListeners();
         BingoTracker.init();
+        if (window.HardMode) {
+            HardMode.init();
+        }
         VerseManager.init();
         Leaderboard.init();
 

--- a/scripts/hardmode.js
+++ b/scripts/hardmode.js
@@ -1,0 +1,148 @@
+// Hard Mode 15 Session Challenge with time-based unlocks
+
+const HardMode = {
+    sessions: [],
+    executedReleases: [],
+    schedule: [],
+
+    init() {
+        // Load progress and executed releases
+        const storedSessions = Storage.load(Storage.KEYS.HARDMODE_SESSIONS, []);
+        const storedReleases = Storage.load(Storage.KEYS.HARDMODE_RELEASES, []);
+        HardMode.sessions = Array.isArray(storedSessions) ? storedSessions : [];
+        HardMode.executedReleases = Array.isArray(storedReleases) ? storedReleases : [];
+
+        HardMode.buildSchedule();
+        HardMode.updateProgress();
+        HardMode.checkSchedule();
+        // Check every minute
+        setInterval(HardMode.checkSchedule, 60 * 1000);
+    },
+
+    buildSchedule() {
+        // Base dates for 3 day challenge (Central Time)
+        const day1 = new Date('2025-07-20T10:00:00-05:00'); // Sunday
+        const day2 = new Date('2025-07-21T10:00:00-05:00');
+        const day3 = new Date('2025-07-22T10:00:00-05:00');
+
+        HardMode.schedule = [
+            { time: day1, action: 'start' },
+            { time: new Date('2025-07-20T18:00:00-05:00'), action: 'day1Evening' },
+            { time: day2, action: 'day2Morning' },
+            { time: new Date('2025-07-21T14:00:00-05:00'), action: 'day2Afternoon' },
+            { time: new Date('2025-07-21T18:00:00-05:00'), action: 'day2Evening' },
+            { time: day3, action: 'day3Morning' },
+            { time: new Date('2025-07-22T13:00:00-05:00'), action: 'day3Midday' }
+        ];
+    },
+
+    addSession(session) {
+        if (!HardMode.sessions.includes(session)) {
+            HardMode.sessions.push(session);
+            HardMode.save();
+            HardMode.updateProgress();
+            HardMode.checkCompletion();
+        }
+    },
+
+    updateProgress() {
+        const countEl = document.getElementById('hardmode-count');
+        if (countEl) {
+            countEl.textContent = HardMode.sessions.length.toString();
+        }
+    },
+
+    checkSchedule() {
+        const now = new Date();
+        HardMode.schedule.forEach((item, idx) => {
+            if (!HardMode.executedReleases.includes(idx) && now >= item.time) {
+                HardMode.executedReleases.push(idx);
+                HardMode.save();
+                HardMode.handleAction(item.action);
+            }
+        });
+    },
+
+    handleAction(action) {
+        switch (action) {
+            case 'start':
+                Utils.showNotification('Hard Mode Challenge unlocked!');
+                HardMode.showProgress(true);
+                break;
+            case 'day1Evening':
+                HardMode.day1ProgressCheck();
+                break;
+            case 'day2Morning':
+                HardMode.showTracker();
+                break;
+            case 'day2Afternoon':
+                Utils.showNotification('Mid-day check in!');
+                break;
+            case 'day2Evening':
+                HardMode.day2ProgressCheck();
+                break;
+            case 'day3Morning':
+                Utils.showNotification('Final day!');
+                break;
+            case 'day3Midday':
+                Utils.showNotification('Keep pushing to finish!');
+                break;
+            default:
+                break;
+        }
+    },
+
+    day1ProgressCheck() {
+        const count = HardMode.sessions.length;
+        if (count >= 5) {
+            Utils.showNotification('Day 1 Warrior badge unlocked!');
+        } else if (count >= 3) {
+            Utils.showNotification('Good Start!');
+        } else {
+            Utils.showNotification('Catch Up Tomorrow!', 'warning');
+        }
+    },
+
+    day2ProgressCheck() {
+        const count = HardMode.sessions.length;
+        if (count >= 10) {
+            Utils.showNotification('Two-Day Champion badge unlocked!');
+        } else if (count >= 7) {
+            Utils.showNotification('Push Mode Activated');
+        } else {
+            Utils.showNotification('Redemption Path scheduled', 'warning');
+        }
+    },
+
+    showProgress(show) {
+        const container = document.getElementById('hardmode-progress');
+        if (container) {
+            container.classList.toggle('hidden', !show);
+        }
+    },
+
+    showTracker() {
+        HardMode.showProgress(true);
+        Utils.showNotification('Progress tracker unlocked!');
+    },
+
+    checkCompletion() {
+        const count = HardMode.sessions.length;
+        if (count >= 15) {
+            if (!HardMode.executedReleases.includes('complete')) {
+                HardMode.executedReleases.push('complete');
+                HardMode.save();
+                Utils.showNotification('Hard Mode Champion badge unlocked!');
+            }
+        }
+    },
+
+    save() {
+        Storage.save(Storage.KEYS.HARDMODE_SESSIONS, HardMode.sessions);
+        Storage.save(Storage.KEYS.HARDMODE_RELEASES, HardMode.executedReleases);
+    }
+};
+
+if (typeof window !== 'undefined') {
+    window.HardMode = HardMode;
+}

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -8,7 +8,9 @@ const Storage = {
         BINGO_SUBITEMS_COMPLETIONIST: 'bingoSubItemsCompletionist',
         FAVORITE_VERSES: 'favoriteVerses',
         POLL_RESPONSES: 'pollResponses',
-        USER_PREFERENCES: 'userPreferences'
+        USER_PREFERENCES: 'userPreferences',
+        HARDMODE_SESSIONS: 'hardModeSessions',
+        HARDMODE_RELEASES: 'hardModeReleases'
     },
 
     // Save data to localStorage

--- a/tests/hardmode.test.js
+++ b/tests/hardmode.test.js
@@ -1,0 +1,41 @@
+const { JSDOM } = require('jsdom');
+
+describe('HardMode challenge basics', () => {
+  let HardMode;
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><div id="hardmode-count"></div><div id="hardmode-progress"></div>`);
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.Storage = {
+      KEYS: { HARDMODE_SESSIONS: 'hm_s', HARDMODE_RELEASES: 'hm_r' },
+      load: jest.fn(() => []),
+      save: jest.fn()
+    };
+    global.Utils = { showNotification: jest.fn() };
+    require('../scripts/hardmode.js');
+    HardMode = window.HardMode;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    delete global.window;
+    delete global.document;
+    delete global.Storage;
+    delete global.Utils;
+  });
+
+  test('addSession stores unique sessions', () => {
+    HardMode.init();
+    HardMode.addSession('S1');
+    HardMode.addSession('S1');
+    expect(HardMode.sessions.length).toBe(1);
+  });
+
+  test('checkSchedule triggers start action', () => {
+    HardMode.buildSchedule = () => {
+      HardMode.schedule = [{ time: new Date(Date.now() - 1000), action: 'start' }];
+    };
+    HardMode.init();
+    expect(Utils.showNotification).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- store new Hard Mode progress in Storage
- display Hard Mode session count in the UI
- add `hardmode.js` for time-based unlocks
- init Hard Mode in main app
- test Hard Mode logic

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cebae6ce08331b2679eaeff7a5b09