### PR TITLE
Implement brief cooldown after each challenge

### DIFF
--- a/tests/anti-cheat-rate.test.js
+++ b/tests/anti-cheat-rate.test.js
@@ -5,6 +5,7 @@ describe('rapid completion rate limiting', () => {
     // reset tracking
     AntiCheat.flaggedUsers.clear();
     AntiCheat.lastActions = {};
+    AntiCheat.cooldownMs = 0;
     // allow all challenges
     AntiCheat.isChallengeAvailable = () => true;
   });
@@ -24,5 +25,15 @@ describe('rapid completion rate limiting', () => {
       AntiCheat.recordTileCompletion(user, i);
     }
     expect(AntiCheat.flaggedUsers.has(user)).toBe(true);
+  });
+
+  test('brief cooldown prevents immediate repeat', () => {
+    const user = 'cooldownUser';
+    AntiCheat.cooldownMs = 1000; // 1 second
+    const first = AntiCheat.recordTileCompletion(user, 0);
+    expect(first.allowed).toBe(true);
+    const second = AntiCheat.recordTileCompletion(user, 1);
+    expect(second.allowed).toBe(false);
+    expect(second.type).toBe('cooldown');
   });
 });


### PR DESCRIPTION
## Summary
- introduce a short global cooldown in the anti-cheat system
- enforce cooldown logic in `canCompleteChallenge`
- expose remaining cooldown via `getRemainingCooldown`
- update tests to account for new cooldown behaviour
- increase cooldown to 1 minute

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cedf3ad3083319ef178aec20930ac