### PR TITLE
Bump asset version numbers for cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ visitors to download the new versions by appending a query parameter to the
 file URLs in `index.html`:
 
 ```html
-<link href="styles/global.css?v=2" rel="stylesheet">
-<script src="scripts/app.js?v=2"></script>
+<link href="styles/global.css?v=3" rel="stylesheet">
+<script src="scripts/app.js?v=3"></script>
 ```
 
 Increase the version number whenever you deploy new assets so browsers do not

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="styles/global.css?v=2" rel="stylesheet">
-    <link href="styles/anticheat-styles.css?v=2" rel="stylesheet">
+    <link href="styles/global.css?v=3" rel="stylesheet">
+    <link href="styles/anticheat-styles.css?v=3" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -126,22 +126,22 @@
     </div>
 
 
-    <script src="scripts/utils.js?v=2"></script>
-    <script src="scripts/username-validator.js?v=2"></script>
-    <script src="scripts/username-feedback.js?v=2"></script>
-    <script src="scripts/storage.js?v=2"></script>
-    <script src="scripts/anti-cheat-system.js?v=2"></script>
-    <script src="scripts/bingo.js?v=2"></script>
-    <script src="scripts/bingo-anticheat-integration.js?v=2"></script>
-    <script src="scripts/hardmode.js?v=2"></script>
-    <script src="scripts/verse.js?v=2"></script>
-    <script src="scripts/event-status.js?v=2"></script>
+    <script src="scripts/utils.js?v=3"></script>
+    <script src="scripts/username-validator.js?v=3"></script>
+    <script src="scripts/username-feedback.js?v=3"></script>
+    <script src="scripts/storage.js?v=3"></script>
+    <script src="scripts/anti-cheat-system.js?v=3"></script>
+    <script src="scripts/bingo.js?v=3"></script>
+    <script src="scripts/bingo-anticheat-integration.js?v=3"></script>
+    <script src="scripts/hardmode.js?v=3"></script>
+    <script src="scripts/verse.js?v=3"></script>
+    <script src="scripts/event-status.js?v=3"></script>
 
-    <script src="scripts/firebase-leaderboard.js?v=2"></script>
-    <script src="scripts/firebase-anticheat.js?v=2"></script>
-    <script src="scripts/leaderboard.js?v=2"></script>
-    <script src="scripts/validation-analytics.js?v=2"></script>
-    <script src="scripts/app.js?v=2"></script>
+    <script src="scripts/firebase-leaderboard.js?v=3"></script>
+    <script src="scripts/firebase-anticheat.js?v=3"></script>
+    <script src="scripts/leaderboard.js?v=3"></script>
+    <script src="scripts/validation-analytics.js?v=3"></script>
+    <script src="scripts/app.js?v=3"></script>
 
     <script type="module">
         // Import Firebase modules


### PR DESCRIPTION
## Summary
- update `index.html` asset URLs to use `v=3`
- update README example with new version number

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cf5a1a9288331bd627d46d8120935