### PR TITLE
Move fair play notice to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ visitors to download the new versions by appending a query parameter to the
 file URLs in `index.html`:
 
 ```html
-<link href="styles/global.css?v=3" rel="stylesheet">
-<script src="scripts/app.js?v=3"></script>
+<link href="styles/global.css?v=4" rel="stylesheet">
+<script src="scripts/app.js?v=4"></script>
 ```
 
 Increase the version number whenever you deploy new assets so browsers do not

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="styles/global.css?v=3" rel="stylesheet">
-    <link href="styles/anticheat-styles.css?v=3" rel="stylesheet">
+    <link href="styles/global.css?v=4" rel="stylesheet">
+    <link href="styles/anticheat-styles.css?v=4" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -48,11 +48,6 @@
                     <div class="total-points">
                         Total Points: <span id="total-points">0</span>
                         (<span id="total-progress">0%</span> complete)
-                    </div>
-
-                    <!-- Anti-Cheat Status (initially hidden) -->
-                    <div id="anticheat-status" class="anticheat-status" style="display: none;">
-                        <span id="anticheat-text">Protection active</span>
                     </div>
 
                     <div class="mb-4" id="username-container">
@@ -122,26 +117,30 @@
             <div class="mt-2">
                 <a href="mailto:gathertogether2025@gmail.com" class="btn-secondary btn-compact">Suggest a Challenge</a>
             </div>
-        </footer>
+            <div id="anticheat-status" class="anticheat-status" style="display: none;">
+                <span id="anticheat-text">Protection active</span>
+            </div>
+
+</footer>
     </div>
 
 
-    <script src="scripts/utils.js?v=3"></script>
-    <script src="scripts/username-validator.js?v=3"></script>
-    <script src="scripts/username-feedback.js?v=3"></script>
-    <script src="scripts/storage.js?v=3"></script>
-    <script src="scripts/anti-cheat-system.js?v=3"></script>
-    <script src="scripts/bingo.js?v=3"></script>
-    <script src="scripts/bingo-anticheat-integration.js?v=3"></script>
-    <script src="scripts/hardmode.js?v=3"></script>
-    <script src="scripts/verse.js?v=3"></script>
-    <script src="scripts/event-status.js?v=3"></script>
+    <script src="scripts/utils.js?v=4"></script>
+    <script src="scripts/username-validator.js?v=4"></script>
+    <script src="scripts/username-feedback.js?v=4"></script>
+    <script src="scripts/storage.js?v=4"></script>
+    <script src="scripts/anti-cheat-system.js?v=4"></script>
+    <script src="scripts/bingo.js?v=4"></script>
+    <script src="scripts/bingo-anticheat-integration.js?v=4"></script>
+    <script src="scripts/hardmode.js?v=4"></script>
+    <script src="scripts/verse.js?v=4"></script>
+    <script src="scripts/event-status.js?v=4"></script>
 
-    <script src="scripts/firebase-leaderboard.js?v=3"></script>
-    <script src="scripts/firebase-anticheat.js?v=3"></script>
-    <script src="scripts/leaderboard.js?v=3"></script>
-    <script src="scripts/validation-analytics.js?v=3"></script>
-    <script src="scripts/app.js?v=3"></script>
+    <script src="scripts/firebase-leaderboard.js?v=4"></script>
+    <script src="scripts/firebase-anticheat.js?v=4"></script>
+    <script src="scripts/leaderboard.js?v=4"></script>
+    <script src="scripts/validation-analytics.js?v=4"></script>
+    <script src="scripts/app.js?v=4"></script>
 
     <script type="module">
         // Import Firebase modules

--- a/styles/global.css
+++ b/styles/global.css
@@ -1092,9 +1092,9 @@ body {
 
 /* Anti-cheat status indicator */
 .anticheat-status {
-    position: fixed;
-    bottom: 1rem;
-    right: 1rem;
+    position: static;
+    display: inline-block;
+    margin-top: 0.5rem;
     background: var(--glass-bg);
     backdrop-filter: blur(10px);
     border: 1px solid var(--glass-border);
@@ -1215,8 +1215,7 @@ body {
     .anticheat-status {
         font-size: 0.75rem;
         padding: 0.25rem 0.5rem;
-        bottom: 0.5rem;
-        right: 0.5rem;
+        margin-top: 0.25rem;
     }
 
     .suspicious-warning-content {
@@ -1431,9 +1430,9 @@ body {
 
 /* Anti-Cheat Status Indicator */
 .anticheat-status {
-    position: fixed;
-    bottom: 1rem;
-    right: 1rem;
+    position: static;
+    display: inline-block;
+    margin-top: 0.5rem;
     background: var(--glass-bg);
     backdrop-filter: blur(10px);
     border: 1px solid var(--glass-border);


### PR DESCRIPTION
## Summary
- relocate the anti-cheat status element into the page footer
- update styles so the notice is static rather than fixed
- bump asset version numbers for cache busting

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cf7b9cfd8833184f812a9e23d79a8