### PR TITLE
Use hours for longer countdowns

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -40,7 +40,8 @@ const Utils = {
     // Short label for countdown timer
     formatDurationShort: (ms) => {
         const minutes = Math.ceil(ms / (1000 * 60));
-        if (minutes < 60) return `${minutes}m`;
+        // Use hours once the countdown exceeds 90 minutes
+        if (minutes < 90) return `${minutes}m`;
         const hours = Math.ceil(ms / (1000 * 60 * 60));
         if (hours < 24) return `${hours}h`;
         const days = Math.ceil(ms / (1000 * 60 * 60 * 24));

--- a/tests/utils-duration.test.js
+++ b/tests/utils-duration.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('formatDurationShort switches to hours at 90 minutes', () => {
+  const code = fs.readFileSync(path.join(__dirname, '../scripts/utils.js'), 'utf8');
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  const Utils = vm.runInContext('Utils', context);
+
+  expect(Utils.formatDurationShort(89 * 60 * 1000)).toBe('89m');
+  expect(Utils.formatDurationShort(90 * 60 * 1000)).toBe('2h');
+});


### PR DESCRIPTION
## Summary
- adjust formatDurationShort to use hours once remaining time exceeds 90 minutes
- test countdown formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cfb3236948331a88b412eb9a1acf1