### PR TITLE
Add orange to hair color list

### DIFF
--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -174,7 +174,7 @@ const COMPLETIONIST_CHALLENGES = [
         'Concordia University Irvine'
     ] },
     { text: 'Take a picture with someone with each hair color',
-      sublist: ['Brown', 'Blonde', 'Black', 'Red', 'Pink', 'Green', 'Bald'] }
+      sublist: ['Brown', 'Blonde', 'Black', 'Red', 'Pink', 'Green', 'Orange', 'Bald'] }
 ];
 
 const BingoTracker = {


### PR DESCRIPTION
## Summary
- include Orange in hair color challenge list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d2f5358b08331a9dd329eb9960d5f