### PR TITLE
Bump asset version queries for cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ visitors to download the new versions by appending a query parameter to the
 file URLs in `index.html`:
 
 ```html
-<link href="styles/global.css?v=6" rel="stylesheet">
-<script src="scripts/app.js?v=6"></script>
+<link href="styles/global.css?v=7" rel="stylesheet">
+<script src="scripts/app.js?v=7"></script>
 ```
 
 Increase the version number whenever you deploy new assets so browsers do not

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="styles/global.css?v=6" rel="stylesheet">
-    <link href="styles/anticheat-styles.css?v=6" rel="stylesheet">
+    <link href="styles/global.css?v=7" rel="stylesheet">
+    <link href="styles/anticheat-styles.css?v=7" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -125,22 +125,22 @@
     </div>
 
 
-    <script src="scripts/utils.js?v=6"></script>
-    <script src="scripts/username-validator.js?v=6"></script>
-    <script src="scripts/username-feedback.js?v=6"></script>
-    <script src="scripts/storage.js?v=6"></script>
-    <script src="scripts/anti-cheat-system.js?v=6"></script>
-    <script src="scripts/bingo.js?v=6"></script>
-    <script src="scripts/bingo-anticheat-integration.js?v=6"></script>
-    <script src="scripts/hardmode.js?v=6"></script>
-    <script src="scripts/verse.js?v=6"></script>
-    <script src="scripts/event-status.js?v=6"></script>
+    <script src="scripts/utils.js?v=7"></script>
+    <script src="scripts/username-validator.js?v=7"></script>
+    <script src="scripts/username-feedback.js?v=7"></script>
+    <script src="scripts/storage.js?v=7"></script>
+    <script src="scripts/anti-cheat-system.js?v=7"></script>
+    <script src="scripts/bingo.js?v=7"></script>
+    <script src="scripts/bingo-anticheat-integration.js?v=7"></script>
+    <script src="scripts/hardmode.js?v=7"></script>
+    <script src="scripts/verse.js?v=7"></script>
+    <script src="scripts/event-status.js?v=7"></script>
 
-    <script src="scripts/firebase-leaderboard.js?v=6"></script>
-    <script src="scripts/firebase-anticheat.js?v=6"></script>
-    <script src="scripts/leaderboard.js?v=6"></script>
-    <script src="scripts/validation-analytics.js?v=6"></script>
-    <script src="scripts/app.js?v=6"></script>
+    <script src="scripts/firebase-leaderboard.js?v=7"></script>
+    <script src="scripts/firebase-anticheat.js?v=7"></script>
+    <script src="scripts/leaderboard.js?v=7"></script>
+    <script src="scripts/validation-analytics.js?v=7"></script>
+    <script src="scripts/app.js?v=7"></script>
 
     <script type="module">
         // Import Firebase modules


### PR DESCRIPTION
## Summary
- update asset query strings to `v=7`
- bump example cache-busting snippet in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d38ecf89c8331b10ccb80f70a5d37