### PR TITLE
Remove global cooldown checks

### DIFF
--- a/scripts/bingo-anticheat-integration.js
+++ b/scripts/bingo-anticheat-integration.js
@@ -35,12 +35,6 @@
                     } else if (mode === 'completionist') {
                         message = `This Hard Mode challenge unlocks later in the event. Keep checking back!`;
                     }
-                } else if (validation.type === 'cooldown') {
-                    let friendly = `${Math.ceil(validation.remainingTime / (1000 * 60))} minutes`;
-                    if (window.Utils && typeof Utils.formatDuration === 'function') {
-                        friendly = Utils.formatDuration(validation.remainingTime);
-                    }
-                    message = `Please wait ${friendly} before completing this challenge.`;
                 } else if (validation.type === 'rate_limit') {
                     message = `Slow down there, speed racer! 🏃‍♂️ Take time to truly experience each challenge.`;
                 }
@@ -71,7 +65,7 @@
         if (!tile) return;
         
         // Remove existing state classes
-        tile.classList.remove('locked', 'on-cooldown', 'newly-unlocked');
+        tile.classList.remove('locked', 'newly-unlocked');
         
         // Add appropriate state class
         if (validation && !validation.allowed) {
@@ -80,8 +74,6 @@
                 tracker.showLockIcon(tile);
                 const unlock = ac.getChallengeUnlockTime(tracker.currentMode || 'regular', index);
                 tracker.updateCountdown(tile, unlock);
-            } else if (validation.type === 'cooldown') {
-                // Cooldown visuals have been removed
             }
         } else {
             tracker.updateCountdown(tile, null);

--- a/tests/anti-cheat-rate.test.js
+++ b/tests/anti-cheat-rate.test.js
@@ -5,7 +5,6 @@ describe('rapid completion rate limiting', () => {
     // reset tracking
     AntiCheat.flaggedUsers.clear();
     AntiCheat.lastActions = {};
-    AntiCheat.cooldownMs = 0;
     // allow all challenges
     AntiCheat.isChallengeAvailable = () => true;
   });
@@ -27,13 +26,4 @@ describe('rapid completion rate limiting', () => {
     expect(AntiCheat.flaggedUsers.has(user)).toBe(true);
   });
 
-  test('brief cooldown prevents immediate repeat', () => {
-    const user = 'cooldownUser';
-    AntiCheat.cooldownMs = 1000; // 1 second
-    const first = AntiCheat.recordTileCompletion(user, 0);
-    expect(first.allowed).toBe(true);
-    const second = AntiCheat.recordTileCompletion(user, 1);
-    expect(second.allowed).toBe(false);
-    expect(second.type).toBe('cooldown');
-  });
 });


### PR DESCRIPTION
## Summary
- remove the global cooldown tracking from AntiCheatSystem
- drop cooldown messaging and styling from bingo integration
- update rate limit test to reflect removal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d48fdb5a08331bd9484452ade3ec7