### PR TITLE
Add clothespin challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ visitors to download the new versions by appending a query parameter to the
 file URLs in `index.html`:
 
 ```html
-<link href="styles/global.css?v=7" rel="stylesheet">
-<script src="scripts/app.js?v=7"></script>
+<link href="styles/global.css?v=8" rel="stylesheet">
+<script src="scripts/app.js?v=8"></script>
 ```
 
 Increase the version number whenever you deploy new assets so browsers do not

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="styles/global.css?v=7" rel="stylesheet">
-    <link href="styles/anticheat-styles.css?v=7" rel="stylesheet">
+    <link href="styles/global.css?v=8" rel="stylesheet">
+    <link href="styles/anticheat-styles.css?v=8" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -125,22 +125,22 @@
     </div>
 
 
-    <script src="scripts/utils.js?v=7"></script>
-    <script src="scripts/username-validator.js?v=7"></script>
-    <script src="scripts/username-feedback.js?v=7"></script>
-    <script src="scripts/storage.js?v=7"></script>
-    <script src="scripts/anti-cheat-system.js?v=7"></script>
-    <script src="scripts/bingo.js?v=7"></script>
-    <script src="scripts/bingo-anticheat-integration.js?v=7"></script>
-    <script src="scripts/hardmode.js?v=7"></script>
-    <script src="scripts/verse.js?v=7"></script>
-    <script src="scripts/event-status.js?v=7"></script>
+    <script src="scripts/utils.js?v=8"></script>
+    <script src="scripts/username-validator.js?v=8"></script>
+    <script src="scripts/username-feedback.js?v=8"></script>
+    <script src="scripts/storage.js?v=8"></script>
+    <script src="scripts/anti-cheat-system.js?v=8"></script>
+    <script src="scripts/bingo.js?v=8"></script>
+    <script src="scripts/bingo-anticheat-integration.js?v=8"></script>
+    <script src="scripts/hardmode.js?v=8"></script>
+    <script src="scripts/verse.js?v=8"></script>
+    <script src="scripts/event-status.js?v=8"></script>
 
-    <script src="scripts/firebase-leaderboard.js?v=7"></script>
-    <script src="scripts/firebase-anticheat.js?v=7"></script>
-    <script src="scripts/leaderboard.js?v=7"></script>
-    <script src="scripts/validation-analytics.js?v=7"></script>
-    <script src="scripts/app.js?v=7"></script>
+    <script src="scripts/firebase-leaderboard.js?v=8"></script>
+    <script src="scripts/firebase-anticheat.js?v=8"></script>
+    <script src="scripts/leaderboard.js?v=8"></script>
+    <script src="scripts/validation-analytics.js?v=8"></script>
+    <script src="scripts/app.js?v=8"></script>
 
     <script type="module">
         // Import Firebase modules

--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -72,7 +72,8 @@ const AntiCheatSystem = {
             [21, 45],  // Share meal with group - 45 min
             [22, 30],  // Have a conversation entirely in Disney lyrics - 30 min
             [23, 5],   // Social media post - 5 min
-            [24, 10]   // High-five 10 people - 10 min
+            [24, 10],  // High-five 10 people - 10 min
+            [25, 5]    // Put a clothespin on someone's bag - 5 min
         ]));
 
         // Completionist challenges (in hours) - much longer intervals

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -26,7 +26,8 @@ const BINGO_CHALLENGES = [
     "Have an entire conversation with someone in Disney lyrics",
     "Post about the gathering on social media",
     "Give a high-five to 10 different people",
-    "Ask someone where the bubbler is"
+    "Ask someone where the bubbler is",
+    "Put a clothespin on someone's bag without them noticing"
 ];
 
 const US_STATES = [


### PR DESCRIPTION
## Summary
- include a new challenge about sneaking a clothespin on someone's bag
- bump asset query strings to `v=8` to refresh caches
- update anti-cheat rules with an interval for the clothespin challenge

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d5f25160083318a5e3a709fdd0a87