### PR TITLE
Remove gating on Saturday mass event challenge

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -108,14 +108,9 @@ const AntiCheatSystem = {
         if (dayOfEvent > 7) return true;
 
         if (mode === 'regular') {
-            // Mass event challenge unlocks nightly at 7:30pm CT
+            // Mass event challenge is available from the start of the event
             if (index === 2) {
-                const now = new Date();
-                if (now < this.eventConfig.startDate) return false;
-                const centralNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                const unlock = new Date(centralNow);
-                unlock.setHours(19, 30, 0, 0); // 7:30 PM Central
-                return centralNow >= unlock;
+                return dayOfEvent >= 1;
             }
 
             // Communion challenge only on Wednesday during the event
@@ -389,12 +384,8 @@ const AntiCheatSystem = {
         if (dayOfEvent > 7) return null; // Event concluded
 
         if (mode === 'regular') {
-            if (index === 2) { // Mass event nightly 7:30pm CT
-                const now = new Date();
-                const centralNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                const unlock = new Date(centralNow);
-                unlock.setHours(19, 30, 0, 0);
-                return centralNow >= unlock ? null : unlock;
+            if (index === 2) { // Mass event available from day 1
+                return dayOfEvent >= 1 ? null : start;
             }
             if (index === 16) { // Mass event plus 10pm CT
                 const now = new Date();

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -420,7 +420,7 @@ const BingoTracker = {
             if (isKindness) {
                 unlocked = dayOfEvent > i;
             } else if (isMassEvent) {
-                unlocked = centralNow >= getMassUnlockTime(i);
+                unlocked = i === 0 || centralNow >= getMassUnlockTime(i);
             }
             if (challenge.freeText) {
                 const val = progress[i] || '';
@@ -453,7 +453,7 @@ const BingoTracker = {
                     return;
                 }
                 const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                if (isMassEvent && nowCentral < getMassUnlockTime(sub)) {
+                if (isMassEvent && sub > 0 && nowCentral < getMassUnlockTime(sub)) {
                     if (window.Utils && Utils.showNotification) {
                         Utils.showNotification('This mass event unlocks at 7:30 PM CT.', 'warning');
                     }
@@ -490,7 +490,7 @@ const BingoTracker = {
                     return;
                 }
                 const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                if (isMassEvent && nowCentral < getMassUnlockTime(sub)) {
+                if (isMassEvent && sub > 0 && nowCentral < getMassUnlockTime(sub)) {
                     if (window.Utils && Utils.showNotification) {
                         Utils.showNotification('This mass event unlocks at 7:30 PM CT.', 'warning');
                     }

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -60,11 +60,11 @@ describe('challenge availability schedule', () => {
     jest.useRealTimers();
   });
 
-  test('mass event challenge unlocks at 7:30pm CT', () => {
+  test('mass event challenge available from day 1 regardless of time', () => {
     jest.useFakeTimers();
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    jest.setSystemTime(new Date('2025-07-19T19:29:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(false);
+    jest.setSystemTime(new Date('2025-07-19T19:00:00-05:00'));
+    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
     jest.setSystemTime(new Date('2025-07-19T19:31:00-05:00'));
     expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
     jest.useRealTimers();

--- a/tests/hardmode.test.js
+++ b/tests/hardmode.test.js
@@ -25,6 +25,7 @@ describe('HardMode challenge basics', () => {
   });
 
   test('addSession stores unique sessions', () => {
+    HardMode.buildSchedule = () => { HardMode.schedule = []; };
     HardMode.init();
     HardMode.addSession('S1');
     HardMode.addSession('S1');


### PR DESCRIPTION
## Summary
- allow the Saturday mass event challenge from the start of the event
- unlock the first mass event sub-item immediately
- adjust anti-cheat availability tests
- prevent HardMode test interference from schedule

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e23d8cfac833198f50c78b4f0c1ed