### PR TITLE
Default hard mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This demo is publicly hosted through [GitHub Pages](https://realtreasury.github.
 It is **not** running on WordPress.com and the page is served directly rather than being embedded in an iframe. Simply visit the link above to use the
 app without any additional setup. The project is intentionally lightweight and uses
 vanilla JavaScript without external frameworks. The challenge tracker now supports
-both a regular list and a more difficult **completionist** mode that can be
-toggled in the interface. Completionist challenges with multiple tasks open in a
+both a regular list and a more difficult **completionist** mode. The page starts
+in this Hard Mode by default, but you can switch modes using the buttons at the
+top of the challenge area. Completionist challenges with multiple tasks open in a
 sublist view that can be dismissed via the close button, clicking outside the
 list or pressing <kbd>Esc</kbd>. For sublists with numbered placeholders such as
 "Meet people from 5 different countries," tapping a placeholder lets you enter

--- a/index.html
+++ b/index.html
@@ -63,9 +63,9 @@
                     </div>
 
                     <div class="card-selector">
-                        <button id="leaderboard-btn" class="card-type-btn active" data-type="leaderboard">🏅 Leaderboard</button>
+                        <button id="leaderboard-btn" class="card-type-btn" data-type="leaderboard">🏅 Leaderboard</button>
                         <button class="card-type-btn" data-type="regular">🎯 Regular</button>
-                        <button class="card-type-btn completionist" data-type="completionist">🏆 Hard Mode</button>
+                        <button class="card-type-btn completionist active" data-type="completionist">🏆 Hard Mode</button>
                     </div>
 
                     <div class="stats-container">


### PR DESCRIPTION
## Summary
- start the challenge tracker in Hard Mode instead of the leaderboard
- clarify README to mention Hard Mode is now the default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e7044406c83318f511301c626e22b