### PR TITLE
Bump asset version to v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ visitors to download the new versions by appending a query parameter to the
 file URLs in `index.html`:
 
 ```html
-<link href="styles/global.css?v=9" rel="stylesheet">
-<script src="scripts/app.js?v=9"></script>
+<link href="styles/global.css?v=10" rel="stylesheet">
+<script src="scripts/app.js?v=10"></script>
 ```
 
 Increase the version number whenever you deploy new assets so browsers do not

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="styles/global.css?v=9" rel="stylesheet">
-    <link href="styles/anticheat-styles.css?v=9" rel="stylesheet">
+    <link href="styles/global.css?v=10" rel="stylesheet">
+    <link href="styles/anticheat-styles.css?v=10" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -127,22 +127,22 @@
     </div>
 
 
-    <script src="scripts/utils.js?v=9"></script>
-    <script src="scripts/username-validator.js?v=9"></script>
-    <script src="scripts/username-feedback.js?v=9"></script>
-    <script src="scripts/storage.js?v=9"></script>
-    <script src="scripts/anti-cheat-system.js?v=9"></script>
-    <script src="scripts/bingo.js?v=9"></script>
-    <script src="scripts/bingo-anticheat-integration.js?v=9"></script>
-    <script src="scripts/hardmode.js?v=9"></script>
-    <script src="scripts/verse.js?v=9"></script>
-    <script src="scripts/event-status.js?v=9"></script>
+    <script src="scripts/utils.js?v=10"></script>
+    <script src="scripts/username-validator.js?v=10"></script>
+    <script src="scripts/username-feedback.js?v=10"></script>
+    <script src="scripts/storage.js?v=10"></script>
+    <script src="scripts/anti-cheat-system.js?v=10"></script>
+    <script src="scripts/bingo.js?v=10"></script>
+    <script src="scripts/bingo-anticheat-integration.js?v=10"></script>
+    <script src="scripts/hardmode.js?v=10"></script>
+    <script src="scripts/verse.js?v=10"></script>
+    <script src="scripts/event-status.js?v=10"></script>
 
-    <script src="scripts/firebase-leaderboard.js?v=9"></script>
-    <script src="scripts/firebase-anticheat.js?v=9"></script>
-    <script src="scripts/leaderboard.js?v=9"></script>
-    <script src="scripts/validation-analytics.js?v=9"></script>
-    <script src="scripts/app.js?v=9"></script>
+    <script src="scripts/firebase-leaderboard.js?v=10"></script>
+    <script src="scripts/firebase-anticheat.js?v=10"></script>
+    <script src="scripts/leaderboard.js?v=10"></script>
+    <script src="scripts/validation-analytics.js?v=10"></script>
+    <script src="scripts/app.js?v=10"></script>
 
     <script type="module">
         // Import Firebase modules


### PR DESCRIPTION
## Summary
- bump cache-busting query parameter to v10 in `index.html`
- update README with new version snippet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e76a9f838833192e4d919f7945b2a