### PR TITLE
Move hair color challenge earlier in hard mode

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -133,11 +133,11 @@ const AntiCheatSystem = {
             return dayOfEvent >= 1;
         } else if (mode === 'completionist') {
             // Custom unlock schedule for certain challenges
-            if (index === 12) {
+            if (index === 13) {
                 // Convention center game challenge available for the entire event
                 return dayOfEvent >= 1;
             }
-            if (index === 8) {
+            if (index === 9) {
                 // Mass event hard mode unlocks at 7:30pm CT on day 1
                 const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
                 if (nowCentral < this.eventConfig.startDate) return false;
@@ -145,31 +145,31 @@ const AntiCheatSystem = {
                 const diffHours = (nowCentral - this.eventConfig.startDate) / (1000 * 60 * 60);
                 return diffHours >= 19.5;
             }
-            if (index === 9 || index === 14) {
+            if (index === 10 || index === 15) {
                 // Sessions/workshops and exhibitor booths now available from Day 1
                 return dayOfEvent >= 1;
             }
-            if (index === 13) {
+            if (index === 14) {
                 // District booth prizes available from the start
                 return dayOfEvent >= 1;
             }
-            if (index === 15) {
+            if (index === 2) {
                 // Hair color challenge available from the start
                 return dayOfEvent >= 1;
             }
-            if (index === 6) {
+            if (index === 7) {
                 // Social media friend challenge available from the start
                 return dayOfEvent >= 1;
             }
-            if (index === 7) {
+            if (index === 8) {
                 // Daily acts of kindness available from the start
                 return dayOfEvent >= 1;
             }
-            if (index === 10) {
+            if (index === 11) {
                 // Daily photo challenge available from the start
                 return dayOfEvent >= 1;
             }
-            if (index === 11) {
+            if (index === 12) {
                 // Photos with main speakers available from the start
                 return dayOfEvent >= 1;
             }
@@ -407,21 +407,21 @@ const AntiCheatSystem = {
             if (dayOfEvent >= 1) return null;
             return start;
         } else if (mode === 'completionist') {
-            if (index === 8) { // Hard mode mass event day 1 7:30pm CT
+            if (index === 9) { // Hard mode mass event day 1 7:30pm CT
                 const unlock = new Date(start);
                 unlock.setHours(19, 30, 0, 0);
                 return Date.now() >= unlock.getTime() ? null : unlock;
             }
-            if (index === 9 || index === 14) { // Sessions/booths day 4
+            if (index === 10 || index === 15) { // Sessions/booths day 4
                 const unlock = new Date(start);
                 unlock.setDate(unlock.getDate() + 3);
                 unlock.setHours(0, 0, 0, 0);
                 return dayOfEvent >= 4 ? null : unlock;
             }
-            if (index === 13) { // District booth prizes available day 1
+            if (index === 14) { // District booth prizes available day 1
                 return dayOfEvent >= 1 ? null : start;
             }
-            if ([6,7,10,11,12,15].includes(index)) {
+            if ([7,8,11,12,13,2].includes(index)) {
                 return dayOfEvent >= 1 ? null : start;
             }
             const unlockDay = Math.floor(index / 3) + 1;

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -47,13 +47,15 @@ const KINDNESS_IDEAS = [
 
 // Index of the "daily random acts" challenge within COMPLETIONIST_CHALLENGES
 // This is used to gate sub items until their release day
-let DAILY_KINDNESS_INDEX = 7;
+let DAILY_KINDNESS_INDEX = 8;
 // Index of the "Attend each mass event" challenge for timed release
-let MASS_EVENT_INDEX = 8;
+let MASS_EVENT_INDEX = 9;
 
 const COMPLETIONIST_CHALLENGES = [
     { text: 'Meet someone from all 50 states', sublist: US_STATES },
     { text: 'Meet people from 5 different countries', sublist: Array.from({length:5},(_,i)=>`Country ${i+1}`), freeText: true },
+    { text: 'Take a picture with someone with each hair color',
+      sublist: ['Brown', 'Blonde', 'Black', 'Red', 'Pink', 'Green', 'Orange', 'Bald'] },
     { text: 'Fast for a meal and donate savings' },
     { text: 'Lead a prayer circle with strangers' },
     { text: 'Write thank-you notes to 10 event volunteers',
@@ -175,8 +177,6 @@ const COMPLETIONIST_CHALLENGES = [
         'Concordia University Chicago',
         'Concordia University Irvine'
     ] },
-    { text: 'Take a picture with someone with each hair color',
-      sublist: ['Brown', 'Blonde', 'Black', 'Red', 'Pink', 'Green', 'Orange', 'Bald'] }
 ];
 
 const BingoTracker = {

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -9,39 +9,39 @@ describe('challenge availability schedule', () => {
 
   test('convention center games available from day 1', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 13)).toBe(true);
     AntiCheat.eventConfig.getDayOfEvent = () => 3;
-    expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 13)).toBe(true);
   });
 
   test('sessions and booths available from day 1', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 9)).toBe(true);
-    expect(AntiCheat.isChallengeAvailable('completionist', 14)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 10)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
   });
 
   test('daily acts of kindness available from start', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 7)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(true);
   });
 
   test('hair color challenge available from day 1', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 2)).toBe(true);
   });
 
   test('photos with main speakers available from day 1', () => {
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(true);
   });
 
   test('mass event hard mode challenge unlocks at 7:30pm CT', () => {
     jest.useFakeTimers();
     AntiCheat.eventConfig.getDayOfEvent = () => 1;
     jest.setSystemTime(new Date('2025-07-19T19:29:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(false);
+    expect(AntiCheat.isChallengeAvailable('completionist', 9)).toBe(false);
     jest.setSystemTime(new Date('2025-07-19T19:31:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('completionist', 8)).toBe(true);
+    expect(AntiCheat.isChallengeAvailable('completionist', 9)).toBe(true);
     jest.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary
- make hair color the 3rd challenge in hard mode
- adjust constants and anti-cheat logic for new indexes
- update tests for new challenge order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e96b313288331aca12c5575afaf75