### PR TITLE
Add Firebase challenge suggestion feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
             <a href="terms.html" class="hover:underline">Terms of Service</a> |
             <a href="privacy.html" class="hover:underline">Privacy Policy</a>
             <div class="mt-2">
-                <a href="mailto:gathertogether2025@gmail.com" class="btn-secondary btn-compact">Suggest a Challenge</a>
+                <button id="suggest-challenge-btn" class="btn-secondary btn-compact">Suggest a Challenge</button>
             </div>
             <div id="anticheat-status" class="anticheat-status" style="display: none;">
                 <span id="anticheat-text">Protection active</span>
@@ -144,6 +144,7 @@
     <script src="scripts/firebase-anticheat.js?v=11"></script>
     <script src="scripts/leaderboard.js?v=11"></script>
     <script src="scripts/validation-analytics.js?v=11"></script>
+    <script src="scripts/challenge-suggest.js?v=11"></script>
     <script src="scripts/app.js?v=11"></script>
 
     <script type="module">

--- a/scripts/challenge-suggest.js
+++ b/scripts/challenge-suggest.js
@@ -1,0 +1,94 @@
+const ChallengeSuggest = {
+    overlay: null,
+    keyHandler: null,
+
+    init() {
+        const btn = document.getElementById('suggest-challenge-btn');
+        if (btn) {
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                ChallengeSuggest.openForm();
+            });
+        }
+    },
+
+    openForm() {
+        // Create overlay using existing sublist styles for consistency
+        const overlay = document.createElement('div');
+        overlay.className = 'sublist-overlay';
+        overlay.innerHTML = `
+            <div class="sublist-content relative">
+                <button class="sublist-close" aria-label="Close">&times;</button>
+                <h3 class="text-xl font-bold mb-4">Suggest a Challenge</h3>
+                <textarea class="challenge-suggest-input" placeholder="Your challenge idea..." rows="4"></textarea>
+                <button class="btn-secondary" id="challenge-submit-btn">Submit</button>
+            </div>
+        `;
+
+        overlay.addEventListener('click', (e) => {
+            if (e.target.classList.contains('sublist-close') || e.target === overlay) {
+                ChallengeSuggest.closeForm();
+            }
+        });
+
+        overlay.querySelector('#challenge-submit-btn').addEventListener('click', ChallengeSuggest.submit);
+
+        ChallengeSuggest.overlay = overlay;
+        document.body.appendChild(overlay);
+
+        ChallengeSuggest.keyHandler = (e) => {
+            if (e.key === 'Escape') {
+                ChallengeSuggest.closeForm();
+            }
+        };
+        document.addEventListener('keydown', ChallengeSuggest.keyHandler);
+    },
+
+    closeForm() {
+        if (ChallengeSuggest.overlay) {
+            ChallengeSuggest.overlay.remove();
+            ChallengeSuggest.overlay = null;
+        }
+        if (ChallengeSuggest.keyHandler) {
+            document.removeEventListener('keydown', ChallengeSuggest.keyHandler);
+            ChallengeSuggest.keyHandler = null;
+        }
+    },
+
+    async submit() {
+        if (!ChallengeSuggest.overlay) return;
+        const textarea = ChallengeSuggest.overlay.querySelector('.challenge-suggest-input');
+        if (!textarea) return;
+        const text = textarea.value.trim();
+        if (text === '') {
+            if (window.Utils && Utils.showNotification) {
+                Utils.showNotification('Please enter a challenge idea', 'error');
+            }
+            return;
+        }
+
+        try {
+            if (!window.firestoreModules || !window.firebaseDB) {
+                throw new Error('Firebase not available');
+            }
+            const { collection, addDoc } = window.firestoreModules;
+            const col = collection(window.firebaseDB, 'challengeSuggestions');
+            await addDoc(col, {
+                text,
+                timestamp: new Date().toISOString(),
+                userId: window.Utils && Utils.getUserId ? Utils.getUserId() : null
+            });
+            if (window.Utils && Utils.showNotification) {
+                Utils.showNotification('Suggestion submitted!');
+            }
+            ChallengeSuggest.closeForm();
+        } catch (err) {
+            console.error('Failed to submit challenge suggestion:', err);
+            if (window.Utils && Utils.showNotification) {
+                Utils.showNotification('Failed to submit suggestion', 'error');
+            }
+        }
+    }
+};
+
+document.addEventListener('DOMContentLoaded', () => ChallengeSuggest.init());

--- a/styles/global.css
+++ b/styles/global.css
@@ -453,6 +453,16 @@ body {
     margin-bottom: 1rem;
 }
 
+.challenge-suggest-input {
+    display: block;
+    width: 100%;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 0.5rem;
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+}
+
 .sub-item-btn:hover {
     background: rgba(124,58,237,0.1);
     border-color: var(--primary-purple);


### PR DESCRIPTION
## Summary
- replace email link with button for submitting challenge ideas
- send suggestion data to Firebase via new script
- style textarea used for suggestions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e97e87f708331a8cf340e84da3fb1