### PR TITLE
Ensure challenge suggestion submits

### DIFF
--- a/scripts/challenge-suggest.js
+++ b/scripts/challenge-suggest.js
@@ -91,4 +91,8 @@ const ChallengeSuggest = {
     }
 };
 
-document.addEventListener('DOMContentLoaded', () => ChallengeSuggest.init());
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => ChallengeSuggest.init());
+} else {
+    ChallengeSuggest.init();
+}

--- a/tests/challenge-suggest.test.js
+++ b/tests/challenge-suggest.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+test('submit adds challenge suggestion to Firestore', async () => {
+  const dom = new JSDOM(`<!DOCTYPE html><button id="suggest-challenge-btn"></button>`);
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    console,
+    Utils: { showNotification: jest.fn(), getUserId: () => 'tester' },
+    firestoreModules: {
+      collection: jest.fn(() => 'col'),
+      addDoc: jest.fn(() => Promise.resolve())
+    },
+    firebaseDB: {}
+  };
+  context.window.Utils = context.Utils;
+  context.window.firestoreModules = context.firestoreModules;
+  context.window.firebaseDB = context.firebaseDB;
+
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, '../scripts/challenge-suggest.js'), 'utf8');
+  vm.runInContext(code, context);
+
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+  dom.window.document.getElementById('suggest-challenge-btn').click();
+  const textarea = dom.window.document.querySelector('.challenge-suggest-input');
+  textarea.value = 'Do a new thing';
+  dom.window.document.getElementById('challenge-submit-btn').click();
+  await new Promise(r => setImmediate(r));
+
+  expect(context.firestoreModules.addDoc).toHaveBeenCalledWith('col', expect.objectContaining({
+    text: 'Do a new thing',
+    userId: 'tester'
+  }));
+});


### PR DESCRIPTION
## Summary
- ensure Suggest a Challenge logic initializes after page load
- test ChallengeSuggest submit behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9a1d31b88331ac3b80a5216a59cb