### PR TITLE
Change rank arrows to 3‑hour window

### DIFF
--- a/server.js
+++ b/server.js
@@ -230,7 +230,7 @@ function getLeaderboard() {
   leaderboard.forEach((entry, index) => {
     const prev = rankHistory[entry.id];
     const currentRank = index + 1;
-    if (prev && now - new Date(prev.timestamp).getTime() <= 24 * 60 * 60 * 1000) {
+    if (prev && now - new Date(prev.timestamp).getTime() <= 3 * 60 * 60 * 1000) {
       entry.rankChange = prev.rank - currentRank;
     } else {
       entry.rankChange = 0;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -88,7 +88,7 @@ test('Leaderboard ranks users and updates existing entries', async () => {
   expect(user2.playerName.toLowerCase()).not.toContain('user');
 });
 
-test('Leaderboard includes rank change within 24 hours', async () => {
+test('Leaderboard includes rank change within 3 hours', async () => {
   await request(app)
     .post('/api/bingo/progress')
     .send({ userId: 'r1', username: 'One', completedTiles: [1] });
@@ -110,7 +110,7 @@ test('Leaderboard includes rank change within 24 hours', async () => {
   const historyPath = path.join(tempDir, 'rank_history.json');
   const history = JSON.parse(fs.readFileSync(historyPath, 'utf8'));
   Object.keys(history).forEach(k => {
-    history[k].timestamp = new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString();
+    history[k].timestamp = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
   });
   fs.writeFileSync(historyPath, JSON.stringify(history, null, 2));
 


### PR DESCRIPTION
## Summary
- compute rank change over the last 3 hours in `server.js`
- update server tests to match the 3‑hour window

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9d90d42c8331997ea06e479c9c27