### PR TITLE
Remove reset progress button

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,6 @@
                         <!-- Grid tiles will be populated by JavaScript -->
                     </div>
 
-                    <div class="text-center mt-6 flex justify-center space-x-4">
-                        <button class="btn-primary" onclick="BingoTracker.reset()">Reset Progress</button>
-                    </div>
 
                     <div id="leaderboard" class="hidden mt-8">
                         <div class="flex justify-between items-center mb-4">


### PR DESCRIPTION
## Summary
- delete the reset progress button from the index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eaba52b30833185e8eceb0d966834