### PR TITLE
Bump cached asset version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ visitors to download the new versions by appending a query parameter to the
 file URLs in `index.html`:
 
 ```html
-<link href="styles/global.css?v=12" rel="stylesheet">
-<script src="scripts/app.js?v=12"></script>
+<link href="styles/global.css?v=13" rel="stylesheet">
+<script src="scripts/app.js?v=13"></script>
 ```
 
 Increase the version number whenever you deploy new assets so browsers do not

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ENDURE - LCMS Youth Gathering</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="styles/global.css?v=12" rel="stylesheet">
-    <link href="styles/anticheat-styles.css?v=12" rel="stylesheet">
+    <link href="styles/global.css?v=13" rel="stylesheet">
+    <link href="styles/anticheat-styles.css?v=13" rel="stylesheet">
 </head>
 <body class="min-h-screen app-loading">
 
@@ -126,23 +126,23 @@
     </div>
 
 
-    <script src="scripts/utils.js?v=12"></script>
-    <script src="scripts/username-validator.js?v=12"></script>
-    <script src="scripts/username-feedback.js?v=12"></script>
-    <script src="scripts/storage.js?v=12"></script>
-    <script src="scripts/anti-cheat-system.js?v=12"></script>
-    <script src="scripts/bingo.js?v=12"></script>
-    <script src="scripts/bingo-anticheat-integration.js?v=12"></script>
-    <script src="scripts/hardmode.js?v=12"></script>
-    <script src="scripts/verse.js?v=12"></script>
-    <script src="scripts/event-status.js?v=12"></script>
+    <script src="scripts/utils.js?v=13"></script>
+    <script src="scripts/username-validator.js?v=13"></script>
+    <script src="scripts/username-feedback.js?v=13"></script>
+    <script src="scripts/storage.js?v=13"></script>
+    <script src="scripts/anti-cheat-system.js?v=13"></script>
+    <script src="scripts/bingo.js?v=13"></script>
+    <script src="scripts/bingo-anticheat-integration.js?v=13"></script>
+    <script src="scripts/hardmode.js?v=13"></script>
+    <script src="scripts/verse.js?v=13"></script>
+    <script src="scripts/event-status.js?v=13"></script>
 
-    <script src="scripts/firebase-leaderboard.js?v=12"></script>
-    <script src="scripts/firebase-anticheat.js?v=12"></script>
-    <script src="scripts/leaderboard.js?v=12"></script>
-    <script src="scripts/validation-analytics.js?v=12"></script>
-    <script src="scripts/challenge-suggest.js?v=12"></script>
-    <script src="scripts/app.js?v=12"></script>
+    <script src="scripts/firebase-leaderboard.js?v=13"></script>
+    <script src="scripts/firebase-anticheat.js?v=13"></script>
+    <script src="scripts/leaderboard.js?v=13"></script>
+    <script src="scripts/validation-analytics.js?v=13"></script>
+    <script src="scripts/challenge-suggest.js?v=13"></script>
+    <script src="scripts/app.js?v=13"></script>
 
     <script type="module">
         // Import Firebase modules


### PR DESCRIPTION
## Summary
- increment asset cache-busting query parameter from `v=12` to `v=13` so browsers fetch latest JS/CSS

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ece22fedc833181b221f1cd3ee7a1