### PR TITLE
Enable all challenges

### DIFF
--- a/scripts/anti-cheat-system.js
+++ b/scripts/anti-cheat-system.js
@@ -99,86 +99,7 @@ const AntiCheatSystem = {
 
     // NEW: Check if challenge should be available based on event day
     isChallengeAvailable(mode, index) {
-        const dayOfEvent = this.eventConfig.getDayOfEvent();
-
-        // Before event starts - no challenges available
-        if (dayOfEvent < 1) return false;
-
-        // After event ends - all challenges available for completion
-        if (dayOfEvent > 7) return true;
-
-        if (mode === 'regular') {
-            // Mass event challenge is available from the start of the event
-            if (index === 2) {
-                return dayOfEvent >= 1;
-            }
-
-            // Communion challenge only on Wednesday during the event
-            if (index === 7) {
-                const isWednesday = new Date().getDay() === 3; // 0=Sun,3=Wed
-                return isWednesday;
-            }
-
-            // Mass Event Plus challenge unlocks nightly at 10:00pm CT
-            if (index === 16) {
-                const now = new Date();
-                if (now < this.eventConfig.startDate) return false;
-                const centralNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                const unlock = new Date(centralNow);
-                unlock.setHours(22, 0, 0, 0); // 10:00 PM Central
-                return centralNow >= unlock;
-            }
-
-            // Regular challenges unlock progressively
-            return dayOfEvent >= 1;
-        } else if (mode === 'completionist') {
-            // Custom unlock schedule for certain challenges
-            if (index === 15) {
-                // Convention center game challenge available for the entire event
-                return dayOfEvent >= 1;
-            }
-            if (index === 11) {
-                // Mass event hard mode unlocks at 7:30pm CT on day 1
-                const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                if (nowCentral < this.eventConfig.startDate) return false;
-                if (dayOfEvent > 1) return true;
-                const diffHours = (nowCentral - this.eventConfig.startDate) / (1000 * 60 * 60);
-                return diffHours >= 19.5;
-            }
-            if (index === 12 || index === 4) {
-                // Sessions/workshops and exhibitor booths now available from Day 1
-                return dayOfEvent >= 1;
-            }
-            if (index === 3) {
-                // District booth prizes available from the start
-                return dayOfEvent >= 1;
-            }
-            if (index === 2) {
-                // Hair color challenge available from the start
-                return dayOfEvent >= 1;
-            }
-            if (index === 9) {
-                // Social media friend challenge available from the start
-                return dayOfEvent >= 1;
-            }
-            if (index === 10) {
-                // Daily acts of kindness available from the start
-                return dayOfEvent >= 1;
-            }
-            if (index === 13) {
-                // Daily photo challenge available from the start
-                return dayOfEvent >= 1;
-            }
-            if (index === 14) {
-                // Photos with main speakers available from the start
-                return dayOfEvent >= 1;
-            }
-
-            // Default: unlock groups of three each day
-            const unlockDay = Math.floor(index / 3) + 1;
-            return dayOfEvent >= unlockDay;
-        }
-
+        // Time locks disabled - all challenges available
         return true;
     },
 
@@ -378,60 +299,7 @@ const AntiCheatSystem = {
 
     // NEW: Determine when a challenge will unlock
     getChallengeUnlockTime(mode, index) {
-        const start = new Date(this.eventConfig.startDate);
-        const dayOfEvent = this.eventConfig.getDayOfEvent();
-
-        if (dayOfEvent > 7) return null; // Event concluded
-
-        if (mode === 'regular') {
-            if (index === 2) { // Mass event available from day 1
-                return dayOfEvent >= 1 ? null : start;
-            }
-            if (index === 16) { // Mass event plus 10pm CT
-                const now = new Date();
-                const centralNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                const unlock = new Date(centralNow);
-                unlock.setHours(22, 0, 0, 0);
-                return centralNow >= unlock ? null : unlock;
-            }
-            if (index === 7) { // Communion on Wednesday
-                const now = new Date();
-                const dow = now.getDay();
-                const diff = (3 - dow + 7) % 7; // 3=Wed
-                if (diff === 0 && dayOfEvent >= 1) return null;
-                const next = new Date(now);
-                next.setDate(now.getDate() + diff);
-                next.setHours(0, 0, 0, 0);
-                return next;
-            }
-            if (dayOfEvent >= 1) return null;
-            return start;
-        } else if (mode === 'completionist') {
-            if (index === 11) { // Hard mode mass event day 1 7:30pm CT
-                const unlock = new Date(start);
-                unlock.setHours(19, 30, 0, 0);
-                return Date.now() >= unlock.getTime() ? null : unlock;
-            }
-            if (index === 12 || index === 4) { // Sessions/booths day 4
-                const unlock = new Date(start);
-                unlock.setDate(unlock.getDate() + 3);
-                unlock.setHours(0, 0, 0, 0);
-                return dayOfEvent >= 4 ? null : unlock;
-            }
-            if (index === 3) { // District booth prizes available day 1
-                return dayOfEvent >= 1 ? null : start;
-            }
-            if ([9,10,13,14,3,2].includes(index)) {
-                return dayOfEvent >= 1 ? null : start;
-            }
-            const unlockDay = Math.floor(index / 3) + 1;
-            if (dayOfEvent >= unlockDay) return null;
-            const unlock = new Date(start);
-            unlock.setDate(unlock.getDate() + unlockDay - 1);
-            unlock.setHours(0, 0, 0, 0);
-            return unlock;
-        }
-
+        // Time locks disabled
         return null;
     },
 

--- a/scripts/bingo.js
+++ b/scripts/bingo.js
@@ -403,26 +403,11 @@ const BingoTracker = {
 
         const overlay = document.createElement('div');
         overlay.className = 'sublist-overlay';
-        const dayOfEvent = window.AntiCheatSystem ?
-            window.AntiCheatSystem.eventConfig.getDayOfEvent() : 8;
 
         const isKindness = index === DAILY_KINDNESS_INDEX;
         const isMassEvent = index === MASS_EVENT_INDEX;
-        const centralNow = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-        const getMassUnlockTime = (offset) => {
-            const base = window.AntiCheatSystem ? new Date(window.AntiCheatSystem.eventConfig.startDate) : new Date();
-            base.setDate(base.getDate() + offset);
-            const central = new Date(base.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-            central.setHours(19, 30, 0, 0); // 7:30 PM Central
-            return central;
-        };
         const listItems = challenge.sublist.map((item, i) => {
-            let unlocked = true;
-            if (isKindness) {
-                unlocked = dayOfEvent > i;
-            } else if (isMassEvent) {
-                unlocked = i === 0 || centralNow >= getMassUnlockTime(i);
-            }
+            const unlocked = true;
             if (challenge.freeText) {
                 const val = progress[i] || '';
                 const selected = val ? 'selected' : '';
@@ -447,19 +432,6 @@ const BingoTracker = {
         const handleClick = (e) => {
             if (e.target.matches('.sub-item-btn')) {
                 const sub = parseInt(e.target.dataset.sub,10);
-                if (isKindness && dayOfEvent <= sub) {
-                    if (window.Utils && Utils.showNotification) {
-                        Utils.showNotification(`Come back on Day ${sub+1} to complete this act!`, 'warning');
-                    }
-                    return;
-                }
-                const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                if (isMassEvent && sub > 0 && nowCentral < getMassUnlockTime(sub)) {
-                    if (window.Utils && Utils.showNotification) {
-                        Utils.showNotification('This mass event unlocks at 7:30 PM CT.', 'warning');
-                    }
-                    return;
-                }
                 if (progress.has(sub)) {
                     progress.delete(sub);
                     e.target.classList.remove('selected');
@@ -483,21 +455,6 @@ const BingoTracker = {
         const handleInput = (e) => {
             if (e.target.matches('.sub-item-input')) {
                 const sub = parseInt(e.target.dataset.sub,10);
-                if (isKindness && dayOfEvent <= sub) {
-                    if (window.Utils && Utils.showNotification) {
-                        Utils.showNotification(`Come back on Day ${sub+1} to complete this act!`, 'warning');
-                    }
-                    e.target.value = progress[sub] || '';
-                    return;
-                }
-                const nowCentral = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-                if (isMassEvent && sub > 0 && nowCentral < getMassUnlockTime(sub)) {
-                    if (window.Utils && Utils.showNotification) {
-                        Utils.showNotification('This mass event unlocks at 7:30 PM CT.', 'warning');
-                    }
-                    e.target.value = progress[sub] || '';
-                    return;
-                }
                 const trimmed = e.target.value.trim();
                 if (trimmed === '') {
                     delete progress[sub];

--- a/scripts/hardmode.js
+++ b/scripts/hardmode.js
@@ -1,4 +1,4 @@
-// Hard Mode 15 Session Challenge with time-based unlocks
+// Hard Mode 15 Session Challenge
 
 const HardMode = {
     sessions: [],
@@ -14,26 +14,15 @@ const HardMode = {
 
         HardMode.buildSchedule();
         HardMode.updateProgress();
+        HardMode.showProgress(true);
         HardMode.checkSchedule();
-        // Check every minute
+        // Check every minute (harmless if schedule empty)
         setInterval(HardMode.checkSchedule, 60 * 1000);
     },
 
     buildSchedule() {
-        // Base dates for 3 day challenge (Central Time)
-        const day1 = new Date('2025-07-20T10:00:00-05:00'); // Sunday
-        const day2 = new Date('2025-07-21T10:00:00-05:00');
-        const day3 = new Date('2025-07-22T10:00:00-05:00');
-
-        HardMode.schedule = [
-            { time: day1, action: 'start', points: 0 },
-            { time: new Date('2025-07-20T18:00:00-05:00'), action: 'day1Evening', points: 2 },
-            { time: day2, action: 'day2Morning', points: 2 },
-            { time: new Date('2025-07-21T14:00:00-05:00'), action: 'day2Afternoon', points: 2 },
-            { time: new Date('2025-07-21T18:00:00-05:00'), action: 'day2Evening', points: 3 },
-            { time: day3, action: 'day3Morning', points: 3 },
-            { time: new Date('2025-07-22T13:00:00-05:00'), action: 'day3Midday', points: 3 }
-        ];
+        // Time locks removed - no scheduled releases
+        HardMode.schedule = [];
     },
 
     addSession(session) {

--- a/tests/anti-cheat-availability.test.js
+++ b/tests/anti-cheat-availability.test.js
@@ -1,82 +1,11 @@
 const AntiCheat = require('../scripts/anti-cheat-system');
 
-describe('challenge availability schedule', () => {
-  const originalGetDay = AntiCheat.eventConfig.getDayOfEvent;
-
-  afterEach(() => {
-    AntiCheat.eventConfig.getDayOfEvent = originalGetDay;
-  });
-
-  test('convention center games available from day 1', () => {
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
-    AntiCheat.eventConfig.getDayOfEvent = () => 3;
-    expect(AntiCheat.isChallengeAvailable('completionist', 15)).toBe(true);
-  });
-
-  test('sessions and booths available from day 1', () => {
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 12)).toBe(true);
-    expect(AntiCheat.isChallengeAvailable('completionist', 4)).toBe(true);
-  });
-
-  test('daily acts of kindness available from start', () => {
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 10)).toBe(true);
-  });
-
-  test('hair color challenge available from day 1', () => {
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 2)).toBe(true);
-  });
-
-  test('photos with main speakers available from day 1', () => {
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    expect(AntiCheat.isChallengeAvailable('completionist', 14)).toBe(true);
-  });
-
-  test('mass event hard mode challenge unlocks at 7:30pm CT', () => {
-    jest.useFakeTimers();
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    jest.setSystemTime(new Date('2025-07-19T19:29:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(false);
-    jest.setSystemTime(new Date('2025-07-19T19:31:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('completionist', 11)).toBe(true);
-    jest.useRealTimers();
-  });
-
-  test('communion challenge only available on Wednesday', () => {
-    jest.useFakeTimers();
-    // Monday of event
-    jest.setSystemTime(new Date('2025-07-21T10:00:00Z'));
-    AntiCheat.eventConfig.getDayOfEvent = () => 5;
-    expect(AntiCheat.isChallengeAvailable('regular', 7)).toBe(false);
-
-    // Wednesday of event
-    jest.setSystemTime(new Date('2025-07-23T10:00:00Z'));
-    AntiCheat.eventConfig.getDayOfEvent = () => 7;
-    expect(AntiCheat.isChallengeAvailable('regular', 7)).toBe(true);
-
-    jest.useRealTimers();
-  });
-
-  test('mass event challenge available from day 1 regardless of time', () => {
-    jest.useFakeTimers();
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    jest.setSystemTime(new Date('2025-07-19T19:00:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
-    jest.setSystemTime(new Date('2025-07-19T19:31:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('regular', 2)).toBe(true);
-    jest.useRealTimers();
-  });
-
-  test('mass event plus challenge unlocks at 10pm CT', () => {
-    jest.useFakeTimers();
-    AntiCheat.eventConfig.getDayOfEvent = () => 1;
-    jest.setSystemTime(new Date('2025-07-19T21:59:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('regular', 16)).toBe(false);
-    jest.setSystemTime(new Date('2025-07-19T22:01:00-05:00'));
-    expect(AntiCheat.isChallengeAvailable('regular', 16)).toBe(true);
-    jest.useRealTimers();
+describe('challenge availability always true', () => {
+  test('all challenges available regardless of day', () => {
+    for (let mode of ['regular', 'completionist']) {
+      for (let i = 0; i < 20; i++) {
+        expect(AntiCheat.isChallengeAvailable(mode, i)).toBe(true);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- remove all timed locks from bingo game
- always allow every challenge and remove countdown logic
- eliminate Hard Mode schedule
- simplify anti-cheat availability tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fc0b1fa748331b43e74195aace6db